### PR TITLE
Replace deprecated ioutil with os in main.go

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"sync"
 	"time"
 )
@@ -32,7 +32,7 @@ type RateLimitConfig struct {
 }
 
 func loadConfig(filename string) (*Config, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- switch `ioutil.ReadFile` to `os.ReadFile`
- update imports accordingly

## Testing
- `go build app/main.go`
