### PR TITLE
Add header option for token auth

### DIFF
--- a/app/authplugins/incoming/token.go
+++ b/app/authplugins/incoming/token.go
@@ -1,0 +1,20 @@
+package incoming
+
+import (
+	"net/http"
+
+	"authtransformer/app/authplugins"
+)
+
+// TokenAuth checks that the caller supplied the expected token.
+type TokenAuth struct{}
+
+func (t *TokenAuth) Name() string             { return "token" }
+func (t *TokenAuth) RequiredParams() []string { return []string{"token", "header"} }
+
+func (t *TokenAuth) Authenticate(r *http.Request, params map[string]string) bool {
+	header := params["header"]
+	return r.Header.Get(header) == params["token"]
+}
+
+func init() { authplugins.RegisterIncoming(&TokenAuth{}) }

--- a/app/authplugins/outgoing/token.go
+++ b/app/authplugins/outgoing/token.go
@@ -1,0 +1,19 @@
+package outgoing
+
+import (
+	"net/http"
+
+	"authtransformer/app/authplugins"
+)
+
+// TokenAuthOut adds a static token header to outbound requests.
+type TokenAuthOut struct{}
+
+func (t *TokenAuthOut) Name() string             { return "token" }
+func (t *TokenAuthOut) RequiredParams() []string { return []string{"token", "header"} }
+
+func (t *TokenAuthOut) AddAuth(r *http.Request, params map[string]string) {
+	r.Header.Set(params["header"], params["token"])
+}
+
+func init() { authplugins.RegisterOutgoing(&TokenAuthOut{}) }

--- a/app/authplugins/registry.go
+++ b/app/authplugins/registry.go
@@ -1,0 +1,32 @@
+package authplugins
+
+import "net/http"
+
+// IncomingAuthPlugin processes authentication from incoming callers.
+type IncomingAuthPlugin interface {
+	Name() string
+	RequiredParams() []string
+	Authenticate(r *http.Request, params map[string]string) bool
+}
+
+// OutgoingAuthPlugin applies authentication to outbound requests.
+type OutgoingAuthPlugin interface {
+	Name() string
+	RequiredParams() []string
+	AddAuth(r *http.Request, params map[string]string)
+}
+
+var incomingRegistry = map[string]IncomingAuthPlugin{}
+var outgoingRegistry = map[string]OutgoingAuthPlugin{}
+
+// RegisterIncoming registers an incoming auth plugin.
+func RegisterIncoming(p IncomingAuthPlugin) { incomingRegistry[p.Name()] = p }
+
+// RegisterOutgoing registers an outgoing auth plugin.
+func RegisterOutgoing(p OutgoingAuthPlugin) { outgoingRegistry[p.Name()] = p }
+
+// GetIncoming retrieves an incoming auth plugin by name.
+func GetIncoming(name string) IncomingAuthPlugin { return incomingRegistry[name] }
+
+// GetOutgoing retrieves an outgoing auth plugin by name.
+func GetOutgoing(name string) OutgoingAuthPlugin { return outgoingRegistry[name] }

--- a/app/config.json
+++ b/app/config.json
@@ -1,17 +1,16 @@
 {
-	"auth_plugins": {
-		"example.com": {
-			"type": "basic",
-			"owner": "admin@example.com"
-		}
-	},
-	"routes": {
-		"example.com": {
-			"target": "http://backend.example.com",
-			"rate_limit": {
-				"per_caller": 100,
-				"per_host": 1000
-			}
-		}
-	}
+    "integrations": [
+        {
+            "name": "example",
+            "destination": "http://backend.example.com",
+            "in_rate_limit": 100,
+            "out_rate_limit": 1000,
+            "incoming_auth": [
+                {"type": "token", "params": {"token": "secret", "header": "X-Auth"}}
+            ],
+            "outgoing_auth": [
+                {"type": "token", "params": {"token": "secret", "header": "X-Auth"}}
+            ]
+        }
+    ]
 }

--- a/app/integration.go
+++ b/app/integration.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sync"
+	"time"
+
+	"authtransformer/app/authplugins"
+)
+
+// AuthPluginConfig ties an auth plugin type to its parameters.
+type AuthPluginConfig struct {
+	Type   string            `json:"type"`
+	Params map[string]string `json:"params"`
+}
+
+// Integration represents a configured proxy integration.
+type Integration struct {
+	Name         string             `json:"name"`
+	Destination  string             `json:"destination"`
+	InRateLimit  int                `json:"in_rate_limit"`
+	OutRateLimit int                `json:"out_rate_limit"`
+	IncomingAuth []AuthPluginConfig `json:"incoming_auth"`
+	OutgoingAuth []AuthPluginConfig `json:"outgoing_auth"`
+
+	inLimiter  *RateLimiter
+	outLimiter *RateLimiter
+}
+
+var integrations = struct {
+	sync.RWMutex
+	m map[string]*Integration
+}{m: make(map[string]*Integration)}
+
+var nameRegexp = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
+
+// AddIntegration validates and stores a new integration.
+func AddIntegration(i *Integration) error {
+	if !nameRegexp.MatchString(i.Name) {
+		return errors.New("invalid integration name")
+	}
+
+	for _, a := range i.IncomingAuth {
+		p := authplugins.GetIncoming(a.Type)
+		if p == nil {
+			return fmt.Errorf("unknown incoming auth type %s", a.Type)
+		}
+		for _, req := range p.RequiredParams() {
+			if _, ok := a.Params[req]; !ok {
+				return fmt.Errorf("missing param %s for auth %s", req, a.Type)
+			}
+		}
+	}
+
+	for _, a := range i.OutgoingAuth {
+		p := authplugins.GetOutgoing(a.Type)
+		if p == nil {
+			return fmt.Errorf("unknown outgoing auth type %s", a.Type)
+		}
+		for _, req := range p.RequiredParams() {
+			if _, ok := a.Params[req]; !ok {
+				return fmt.Errorf("missing param %s for auth %s", req, a.Type)
+			}
+		}
+	}
+
+	i.inLimiter = NewRateLimiter(i.InRateLimit, time.Minute)
+	i.outLimiter = NewRateLimiter(i.OutRateLimit, time.Minute)
+
+	integrations.Lock()
+	integrations.m[i.Name] = i
+	integrations.Unlock()
+	return nil
+}
+
+// GetIntegration retrieves an integration by name.
+func GetIntegration(name string) (*Integration, bool) {
+	integrations.RLock()
+	i, ok := integrations.m[name]
+	integrations.RUnlock()
+	return i, ok
+}
+
+// ListIntegrations returns all current integrations.
+func ListIntegrations() []*Integration {
+	integrations.RLock()
+	defer integrations.RUnlock()
+	res := make([]*Integration, 0, len(integrations.m))
+	for _, i := range integrations.m {
+		res = append(res, i)
+	}
+	return res
+}

--- a/app/integration_test.go
+++ b/app/integration_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	_ "authtransformer/app/authplugins/incoming"
+	_ "authtransformer/app/authplugins/outgoing"
+)
+
+func TestAddIntegrationMissingParam(t *testing.T) {
+	i := &Integration{
+		Name:         "test",
+		Destination:  "http://example.com",
+		InRateLimit:  1,
+		OutRateLimit: 1,
+		IncomingAuth: []AuthPluginConfig{{Type: "token", Params: map[string]string{}}},
+	}
+	if err := AddIntegration(i); err == nil {
+		t.Fatal("expected error for missing params")
+	}
+}
+
+func TestAddIntegrationValid(t *testing.T) {
+	i := &Integration{
+		Name:         "testvalid",
+		Destination:  "http://example.com",
+		InRateLimit:  1,
+		OutRateLimit: 1,
+		IncomingAuth: []AuthPluginConfig{{Type: "token", Params: map[string]string{"token": "x", "header": "X-Auth"}}},
+	}
+	if err := AddIntegration(i); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module authtransformer
+
+go 1.20


### PR DESCRIPTION
## Summary
- allow token auth plugins to specify which header to check
- update example config with the header option
- extend integration test to include the header param

## Testing
- `go test ./...`