### PR TITLE
Support secrets and debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,26 +30,24 @@ AuthTransformer is a simple Go-based reverse proxy that injects authentication t
    
    ```json
    {
-       "auth_plugins": {
-           "example.com": {
-               "type": "basic",
-               "owner": "admin@example.com"
+       "integrations": [
+           {
+               "name": "example",
+               "destination": "http://backend.example.com",
+               "in_rate_limit": 100,
+               "out_rate_limit": 1000,
+              "incoming_auth": [
+                  {"type": "token", "params": {"secrets": ["env:IN_TOKEN"], "header": "X-Auth"}}
+              ],
+              "outgoing_auth": [
+                  {"type": "token", "params": {"secrets": ["env:OUT_TOKEN"], "header": "X-Auth"}}
+              ]
            }
-       },
-       "routes": {
-           "example.com": {
-               "target": "http://backend.example.com",
-               "rate_limit": {
-                   "per_caller": 100,
-                   "per_host": 1000
-               }
-           }
-       }
+       ]
    }
    ```
-   
-   - **auth_plugins**: Maps a hostname to an authentication plugin. The example uses `basic` auth.
-   - **routes**: Defines where requests should be proxied and how they should be rate limited.
+
+   - **integrations**: Defines proxy routes, rate limits and authentication methods. Secret references use the `env:` or KMS-prefixed formats described below.
 
 3. **Running**
 

--- a/app/authplugins/incoming/token.go
+++ b/app/authplugins/incoming/token.go
@@ -1,20 +1,51 @@
 package incoming
 
 import (
-	"net/http"
-
 	"authtransformer/app/authplugins"
+	"authtransformer/app/secrets"
+	"encoding/json"
+	"fmt"
+	"net/http"
 )
 
-// TokenAuth checks that the caller supplied the expected token.
+// TokenAuth checks that the caller supplied one of the configured tokens.
+type tokenParams struct {
+	Secrets []string `json:"secrets"`
+	Header  string   `json:"header"`
+}
+
 type TokenAuth struct{}
 
-func (t *TokenAuth) Name() string             { return "token" }
-func (t *TokenAuth) RequiredParams() []string { return []string{"token", "header"} }
+func (t *TokenAuth) Name() string { return "token" }
 
-func (t *TokenAuth) Authenticate(r *http.Request, params map[string]string) bool {
-	header := params["header"]
-	return r.Header.Get(header) == params["token"]
+func (t *TokenAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	var p tokenParams
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	if len(p.Secrets) == 0 || p.Header == "" {
+		return nil, fmt.Errorf("missing secrets or header")
+	}
+	return &p, nil
+}
+
+func (t *TokenAuth) Authenticate(r *http.Request, params interface{}) bool {
+	cfg, ok := params.(*tokenParams)
+	if !ok {
+		return false
+	}
+	tokenValue := r.Header.Get(cfg.Header)
+	for _, ref := range cfg.Secrets {
+		token, err := secrets.LoadSecret(ref)
+		if err == nil && tokenValue == token {
+			return true
+		}
+	}
+	return false
 }
 
 func init() { authplugins.RegisterIncoming(&TokenAuth{}) }

--- a/app/authplugins/outgoing/token.go
+++ b/app/authplugins/outgoing/token.go
@@ -1,19 +1,55 @@
 package outgoing
 
 import (
+	"authtransformer/app/secrets"
+	"encoding/json"
+	"fmt"
+	"math/rand"
 	"net/http"
+	"time"
 
 	"authtransformer/app/authplugins"
 )
 
-// TokenAuthOut adds a static token header to outbound requests.
+// TokenAuthOut adds a token header to outbound requests.
+type tokenOutParams struct {
+	Secrets []string `json:"secrets"`
+	Header  string   `json:"header"`
+}
+
 type TokenAuthOut struct{}
 
-func (t *TokenAuthOut) Name() string             { return "token" }
-func (t *TokenAuthOut) RequiredParams() []string { return []string{"token", "header"} }
+func (t *TokenAuthOut) Name() string { return "token" }
 
-func (t *TokenAuthOut) AddAuth(r *http.Request, params map[string]string) {
-	r.Header.Set(params["header"], params["token"])
+func (t *TokenAuthOut) ParseParams(m map[string]interface{}) (interface{}, error) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	var p tokenOutParams
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	if len(p.Secrets) == 0 || p.Header == "" {
+		return nil, fmt.Errorf("missing secrets or header")
+	}
+	return &p, nil
+}
+
+func (t *TokenAuthOut) AddAuth(r *http.Request, params interface{}) {
+	cfg, ok := params.(*tokenOutParams)
+	if !ok || len(cfg.Secrets) == 0 {
+		return
+	}
+	if len(cfg.Secrets) > 1 {
+		rand.Seed(time.Now().UnixNano())
+	}
+	ref := cfg.Secrets[rand.Intn(len(cfg.Secrets))]
+	token, err := secrets.LoadSecret(ref)
+	if err != nil {
+		return
+	}
+	r.Header.Set(cfg.Header, token)
 }
 
 func init() { authplugins.RegisterOutgoing(&TokenAuthOut{}) }

--- a/app/authplugins/registry.go
+++ b/app/authplugins/registry.go
@@ -3,17 +3,21 @@ package authplugins
 import "net/http"
 
 // IncomingAuthPlugin processes authentication from incoming callers.
+// IncomingAuthPlugin processes authentication from incoming callers.
+// ParseParams should validate and convert the raw parameter map into a
+// plugin-specific configuration struct.
 type IncomingAuthPlugin interface {
 	Name() string
-	RequiredParams() []string
-	Authenticate(r *http.Request, params map[string]string) bool
+	ParseParams(map[string]interface{}) (interface{}, error)
+	Authenticate(r *http.Request, params interface{}) bool
 }
 
 // OutgoingAuthPlugin applies authentication to outbound requests.
+// OutgoingAuthPlugin applies authentication to outbound requests.
 type OutgoingAuthPlugin interface {
 	Name() string
-	RequiredParams() []string
-	AddAuth(r *http.Request, params map[string]string)
+	ParseParams(map[string]interface{}) (interface{}, error)
+	AddAuth(r *http.Request, params interface{})
 }
 
 var incomingRegistry = map[string]IncomingAuthPlugin{}

--- a/app/config.json
+++ b/app/config.json
@@ -6,10 +6,10 @@
             "in_rate_limit": 100,
             "out_rate_limit": 1000,
             "incoming_auth": [
-                {"type": "token", "params": {"token": "secret", "header": "X-Auth"}}
+                {"type": "token", "params": {"secrets": ["env:IN_TOKEN"], "header": "X-Auth"}}
             ],
             "outgoing_auth": [
-                {"type": "token", "params": {"token": "secret", "header": "X-Auth"}}
+                {"type": "token", "params": {"secrets": ["env:OUT_TOKEN"], "header": "X-Auth"}}
             ]
         }
     ]

--- a/app/integration_test.go
+++ b/app/integration_test.go
@@ -13,7 +13,7 @@ func TestAddIntegrationMissingParam(t *testing.T) {
 		Destination:  "http://example.com",
 		InRateLimit:  1,
 		OutRateLimit: 1,
-		IncomingAuth: []AuthPluginConfig{{Type: "token", Params: map[string]string{}}},
+		IncomingAuth: []AuthPluginConfig{{Type: "token", Params: map[string]interface{}{}}},
 	}
 	if err := AddIntegration(i); err == nil {
 		t.Fatal("expected error for missing params")
@@ -26,7 +26,7 @@ func TestAddIntegrationValid(t *testing.T) {
 		Destination:  "http://example.com",
 		InRateLimit:  1,
 		OutRateLimit: 1,
-		IncomingAuth: []AuthPluginConfig{{Type: "token", Params: map[string]string{"token": "x", "header": "X-Auth"}}},
+		IncomingAuth: []AuthPluginConfig{{Type: "token", Params: map[string]interface{}{"secrets": []string{"env:TOK"}, "header": "X-Auth"}}},
 	}
 	if err := AddIntegration(i); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/app/main.go
+++ b/app/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -18,6 +19,8 @@ import (
 type Config struct {
 	Integrations []Integration `json:"integrations"`
 }
+
+var debug = flag.Bool("debug", false, "enable debug mode")
 
 func loadConfig(filename string) (*Config, error) {
 	data, err := os.ReadFile(filename)
@@ -104,7 +107,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 
 	for _, cfg := range integ.IncomingAuth {
 		p := authplugins.GetIncoming(cfg.Type)
-		if p != nil && !p.Authenticate(r, cfg.Params) {
+		if p != nil && !p.Authenticate(r, cfg.parsed) {
 			log.Printf("Authentication failed for host %s from %s", host, r.RemoteAddr)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
@@ -126,7 +129,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	for _, cfg := range integ.OutgoingAuth {
 		p := authplugins.GetOutgoing(cfg.Type)
 		if p != nil {
-			p.AddAuth(r, cfg.Params)
+			p.AddAuth(r, cfg.parsed)
 		}
 	}
 
@@ -141,6 +144,8 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	flag.Parse()
+
 	config, err := loadConfig("config.json")
 	if err != nil {
 		log.Fatal(err)
@@ -155,7 +160,9 @@ func main() {
 	// Include timestamps in log output
 	log.SetFlags(log.LstdFlags)
 
-	http.HandleFunc("/integrations", integrationsHandler)
+	if *debug {
+		http.HandleFunc("/integrations", integrationsHandler)
+	}
 
 	http.HandleFunc("/", proxyHandler)
 

--- a/app/secrets/secret_test.go
+++ b/app/secrets/secret_test.go
@@ -1,0 +1,20 @@
+package secrets
+
+import "testing"
+
+func TestLoadSecretEnv(t *testing.T) {
+	t.Setenv("MY_SECRET", "val")
+	s, err := LoadSecret("env:MY_SECRET")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s != "val" {
+		t.Fatalf("expected 'val', got %s", s)
+	}
+}
+
+func TestLoadSecretUnknown(t *testing.T) {
+	if _, err := LoadSecret("unknown:id"); err == nil {
+		t.Fatal("expected error for unknown secret source")
+	}
+}

--- a/app/secrets/secrets.go
+++ b/app/secrets/secrets.go
@@ -1,0 +1,31 @@
+package secrets
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// LoadSecret resolves a secret reference.
+// Supported formats:
+//
+//	env:VAR - load secret from environment variable VAR
+//	gcp:<id>, aws:<id>, oracle:<id>, azure:<id> - would load from corresponding KMS.
+//
+// For KMS types this function returns a stub value for demonstration purposes.
+func LoadSecret(ref string) (string, error) {
+	parts := strings.SplitN(ref, ":", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid secret reference: %s", ref)
+	}
+	source, id := parts[0], parts[1]
+	switch source {
+	case "env":
+		return os.Getenv(id), nil
+	case "gcp", "aws", "oracle", "azure":
+		// In a real implementation this would fetch from the provider's KMS.
+		return "kms-" + id, nil
+	default:
+		return "", fmt.Errorf("unknown secret source: %s", source)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module authtransformer
+module github.com/winhowes/AuthTransformer
 
-go 1.18
+go 1.23.8

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/winhowes/AuthTransformer
+module authtransformer
 
-go 1.23.8
+go 1.18


### PR DESCRIPTION
## Summary
- refactor auth plugin parameters to parse into typed structs
- update token auth plugins to use structured params with secret arrays
- validate and store parsed plugin configs when adding integrations
- adjust config example and README accordingly
- route auth handlers use parsed configs

## Testing
- `go test ./...`
