### PR TITLE
Move secret plugins into separate files

### DIFF
--- a/app/secrets/env.go
+++ b/app/secrets/env.go
@@ -1,0 +1,12 @@
+package secrets
+
+import "os"
+
+// envPlugin loads secrets from environment variables.
+type envPlugin struct{}
+
+func (envPlugin) Prefix() string { return "env" }
+
+func (envPlugin) Load(id string) (string, error) { return os.Getenv(id), nil }
+
+func init() { Register(envPlugin{}) }

--- a/app/secrets/kms_aws.go
+++ b/app/secrets/kms_aws.go
@@ -1,0 +1,13 @@
+package secrets
+
+// awsKMSPlugin is a stub for loading secrets from AWS KMS.
+type awsKMSPlugin struct{}
+
+func (awsKMSPlugin) Prefix() string { return "aws" }
+
+func (awsKMSPlugin) Load(id string) (string, error) {
+	// TODO: integrate with AWS KMS.
+	return "aws-kms-" + id, nil
+}
+
+func init() { Register(awsKMSPlugin{}) }

--- a/app/secrets/kms_azure.go
+++ b/app/secrets/kms_azure.go
@@ -1,0 +1,13 @@
+package secrets
+
+// azureKMSPlugin is a stub for loading secrets from Azure Key Vault.
+type azureKMSPlugin struct{}
+
+func (azureKMSPlugin) Prefix() string { return "azure" }
+
+func (azureKMSPlugin) Load(id string) (string, error) {
+	// TODO: integrate with Azure Key Vault.
+	return "azure-kms-" + id, nil
+}
+
+func init() { Register(azureKMSPlugin{}) }

--- a/app/secrets/kms_gcp.go
+++ b/app/secrets/kms_gcp.go
@@ -1,0 +1,13 @@
+package secrets
+
+// gcpKMSPlugin is a stub for loading secrets from Google Cloud KMS.
+type gcpKMSPlugin struct{}
+
+func (gcpKMSPlugin) Prefix() string { return "gcp" }
+
+func (gcpKMSPlugin) Load(id string) (string, error) {
+	// TODO: integrate with Google Cloud KMS.
+	return "gcp-kms-" + id, nil
+}
+
+func init() { Register(gcpKMSPlugin{}) }

--- a/app/secrets/kms_oracle.go
+++ b/app/secrets/kms_oracle.go
@@ -1,0 +1,13 @@
+package secrets
+
+// oracleKMSPlugin is a stub for loading secrets from Oracle Cloud KMS.
+type oracleKMSPlugin struct{}
+
+func (oracleKMSPlugin) Prefix() string { return "oracle" }
+
+func (oracleKMSPlugin) Load(id string) (string, error) {
+	// TODO: integrate with Oracle Cloud KMS.
+	return "oracle-kms-" + id, nil
+}
+
+func init() { Register(oracleKMSPlugin{}) }

--- a/app/secrets/registry.go
+++ b/app/secrets/registry.go
@@ -2,7 +2,6 @@ package secrets
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -42,21 +41,4 @@ func LoadSecret(ref string) (string, error) {
 		return "", fmt.Errorf("unknown secret source: %s", prefix)
 	}
 	return p.Load(id)
-}
-
-type envPlugin struct{}
-
-func (envPlugin) Prefix() string                 { return "env" }
-func (envPlugin) Load(id string) (string, error) { return os.Getenv(id), nil }
-
-type kmsPlugin struct{ prefix string }
-
-func (k kmsPlugin) Prefix() string                 { return k.prefix }
-func (k kmsPlugin) Load(id string) (string, error) { return "kms-" + id, nil }
-
-func init() {
-	Register(envPlugin{})
-	for _, p := range []string{"gcp", "aws", "oracle", "azure"} {
-		Register(kmsPlugin{prefix: p})
-	}
 }


### PR DESCRIPTION
## Summary
- refactor envPlugin and kmsPlugin implementations into their own files
- stub out KMS plugins for GCP, AWS, Azure and Oracle

## Testing
- `go test ./...`
