### PR TITLE
Refactor auth plugin param parsing

### DIFF
--- a/app/authplugins/incoming/token.go
+++ b/app/authplugins/incoming/token.go
@@ -1,7 +1,6 @@
 package incoming
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -24,18 +23,14 @@ func (t *TokenAuth) RequiredParams() []string { return []string{"secrets", "head
 func (t *TokenAuth) OptionalParams() []string { return []string{"prefix"} }
 
 func (t *TokenAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
-	data, err := json.Marshal(m)
+	p, err := authplugins.ParseParams[params](m)
 	if err != nil {
-		return nil, err
-	}
-	var p params
-	if err := json.Unmarshal(data, &p); err != nil {
 		return nil, err
 	}
 	if len(p.Secrets) == 0 || p.Header == "" {
 		return nil, fmt.Errorf("missing secrets or header")
 	}
-	return &p, nil
+	return p, nil
 }
 
 func (t *TokenAuth) Authenticate(r *http.Request, p interface{}) bool {

--- a/app/authplugins/outgoing/token.go
+++ b/app/authplugins/outgoing/token.go
@@ -1,7 +1,6 @@
 package outgoing
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -25,18 +24,14 @@ func (t *TokenAuthOut) RequiredParams() []string { return []string{"secrets", "h
 func (t *TokenAuthOut) OptionalParams() []string { return []string{"prefix"} }
 
 func (t *TokenAuthOut) ParseParams(m map[string]interface{}) (interface{}, error) {
-	data, err := json.Marshal(m)
+	p, err := authplugins.ParseParams[params](m)
 	if err != nil {
-		return nil, err
-	}
-	var p params
-	if err := json.Unmarshal(data, &p); err != nil {
 		return nil, err
 	}
 	if len(p.Secrets) == 0 || p.Header == "" {
 		return nil, fmt.Errorf("missing secrets or header")
 	}
-	return &p, nil
+	return p, nil
 }
 
 func (t *TokenAuthOut) AddAuth(r *http.Request, p interface{}) {

--- a/app/authplugins/parseutil.go
+++ b/app/authplugins/parseutil.go
@@ -1,0 +1,23 @@
+package authplugins
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// ParseParams decodes the map into the provided struct type while
+// disallowing unknown fields. The returned struct pointer will contain
+// the parsed configuration.
+func ParseParams[T any](m map[string]interface{}) (*T, error) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var cfg T
+	if err := dec.Decode(&cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}


### PR DESCRIPTION
## Summary
- share common auth plugin param parsing helper
- use new helper in token auth plugins

## Testing
- `go test ./...`