### PR TITLE
Fix token prefix usage in auth plugins

### DIFF
--- a/app/authplugins/incoming/token.go
+++ b/app/authplugins/incoming/token.go
@@ -19,8 +19,10 @@ type params struct {
 
 type TokenAuth struct{}
 
-func (t *TokenAuth) Name() string             { return "token" }
-func (t *TokenAuth) RequiredParams() []string { return []string{"secrets", "header"} }
+func (t *TokenAuth) Name() string { return "token" }
+func (t *TokenAuth) RequiredParams() []string {
+	return []string{"secrets", "header"}
+}
 func (t *TokenAuth) OptionalParams() []string { return []string{"prefix"} }
 
 func (t *TokenAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
@@ -43,8 +45,7 @@ func (t *TokenAuth) Authenticate(r *http.Request, p interface{}) bool {
 	if !ok {
 		return false
 	}
-	tokenValue := r.Header.Get(cfg.Header)
-	tokenValue = strings.TrimPrefix(tokenValue, cfg.Prefix)
+	tokenValue := strings.TrimPrefix(r.Header.Get(cfg.Header), cfg.Prefix)
 	for _, ref := range cfg.Secrets {
 		token, err := secrets.LoadSecret(ref)
 		if err == nil && tokenValue == token {

--- a/app/authplugins/outgoing/token.go
+++ b/app/authplugins/outgoing/token.go
@@ -20,8 +20,10 @@ type params struct {
 
 type TokenAuthOut struct{}
 
-func (t *TokenAuthOut) Name() string             { return "token" }
-func (t *TokenAuthOut) RequiredParams() []string { return []string{"secrets", "header"} }
+func (t *TokenAuthOut) Name() string { return "token" }
+func (t *TokenAuthOut) RequiredParams() []string {
+	return []string{"secrets", "header"}
+}
 func (t *TokenAuthOut) OptionalParams() []string { return []string{"prefix"} }
 
 func (t *TokenAuthOut) ParseParams(m map[string]interface{}) (interface{}, error) {
@@ -52,8 +54,7 @@ func (t *TokenAuthOut) AddAuth(r *http.Request, p interface{}) {
 	if err != nil {
 		return
 	}
-	token = cfg.Prefix + token
-	r.Header.Set(cfg.Header, token)
+	r.Header.Set(cfg.Header, cfg.Prefix+token)
 }
 
 func init() { authplugins.RegisterOutgoing(&TokenAuthOut{}) }


### PR DESCRIPTION
## Summary
- update required params for token plugins
- use cfg.Prefix consistently for trimming and adding tokens
- fmt go files

## Testing
- `go test ./...`
