### PR TITLE
Add Stop method for RateLimiter

### DIFF
--- a/app/integration_test.go
+++ b/app/integration_test.go
@@ -31,6 +31,10 @@ func TestAddIntegrationValid(t *testing.T) {
 	if err := AddIntegration(i); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	t.Cleanup(func() {
+		i.inLimiter.Stop()
+		i.outLimiter.Stop()
+	})
 }
 
 func TestAddIntegrationOptionalParam(t *testing.T) {
@@ -44,6 +48,10 @@ func TestAddIntegrationOptionalParam(t *testing.T) {
 	if err := AddIntegration(i); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	t.Cleanup(func() {
+		i.inLimiter.Stop()
+		i.outLimiter.Stop()
+	})
 }
 
 func TestAddIntegrationUnknownParam(t *testing.T) {

--- a/app/ratelimiter_test.go
+++ b/app/ratelimiter_test.go
@@ -7,6 +7,7 @@ import (
 
 func TestRateLimiterExceedLimit(t *testing.T) {
 	rl := NewRateLimiter(2, time.Hour)
+	t.Cleanup(rl.Stop)
 	key := "caller"
 
 	if !rl.Allow(key) {
@@ -22,6 +23,7 @@ func TestRateLimiterExceedLimit(t *testing.T) {
 
 func TestRateLimiterReset(t *testing.T) {
 	rl := NewRateLimiter(1, 10*time.Millisecond)
+	t.Cleanup(rl.Stop)
 	key := "caller"
 
 	if !rl.Allow(key) {
@@ -37,5 +39,4 @@ func TestRateLimiterReset(t *testing.T) {
 	if !rl.Allow(key) {
 		t.Fatal("rate limiter should reset after duration")
 	}
-	rl.resetTicker.Stop()
 }


### PR DESCRIPTION
## Summary
- add `Stop` method to `RateLimiter` and a `done` channel to stop goroutines
- use `Stop` in ratelimiter tests
- stop rate limiter goroutines in integration tests

## Testing
- `go test ./...`
