### PR TITLE
Update Go version to 1.24.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Go Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24.3'
+      - name: Run tests
+        run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/winhowes/AuthTransformer
 
-go 1.23.8
+go 1.24.3


### PR DESCRIPTION
## Summary
- bump Go version in `go.mod`
- use Go 1.24.3 in the test workflow

## Testing
- `go test ./...` *(fails: no network access)*