### PR TITLE
Add Terraform deployment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ GO111MODULE=off go test ./...
 ## Logging
 
 AuthTransformer writes log messages to standard output. Each request generates an entry showing the HTTP method, host, path and remote address. Authentication failures and rate limiting events are also logged. The logger is configured with Go's standard time-prefixed format.
+
+## Deploying with Terraform
+
+Example Terraform files are provided in the `terraform` directory to simplify deploying AuthTransformer to AWS using ECS Fargate. Set the required variables for your environment and run `terraform apply` to create the cluster and service.
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,67 @@
+# Simple deployment using AWS ECS Fargate
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_ecs_cluster" "this" {
+  name = "auth-transformer"
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = "auth-transformer"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = var.execution_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "auth-transformer"
+      image = var.container_image
+      portMappings = [{
+        containerPort = 8080
+        hostPort      = 8080
+        protocol      = "tcp"
+      }]
+      environment = [
+        {
+          name  = "IN_TOKEN"
+          value = var.in_token
+        },
+        {
+          name  = "OUT_TOKEN"
+          value = var.out_token
+        }
+      ]
+    }
+  ])
+}
+
+resource "aws_ecs_service" "this" {
+  name            = "auth-transformer"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = var.subnet_ids
+    security_groups = [var.security_group_id]
+  }
+}
+
+output "service_name" {
+  value = aws_ecs_service.this.name
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,7 @@
+output "cluster_id" {
+  value = aws_ecs_cluster.this.id
+}
+
+output "service_name" {
+  value = aws_ecs_service.this.name
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "aws_region" {
+  description = "AWS region to deploy into"
+  type        = string
+}
+
+variable "container_image" {
+  description = "Container image for the application"
+  type        = string
+}
+
+variable "execution_role_arn" {
+  description = "IAM role ARN for ECS tasks"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs for the service"
+  type        = list(string)
+}
+
+variable "security_group_id" {
+  description = "Security group ID for the service"
+  type        = string
+}
+
+variable "in_token" {
+  description = "Token value for incoming auth"
+  type        = string
+}
+
+variable "out_token" {
+  description = "Token value for outgoing auth"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- add Terraform configuration to deploy the proxy on AWS ECS Fargate
- document Terraform deployment instructions

## Testing
- `go test ./...`
