### PR TITLE
Add Google OIDC auth plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ AuthTransformer is a simple Go-based reverse proxy that injects authentication t
 ## Features
 
 - **Reverse Proxy**: Forwards incoming HTTP requests to a target backend based on the requested host.
-- **Pluggable Authentication**: Supports "basic" and "token" authentication types with room for extension.
+- **Pluggable Authentication**: Supports "basic", "token" and Google OIDC authentication types with room for extension.
 - **Rate Limiting**: Limits the number of requests per caller and per host within a rolling window.
 - **Configuration Driven**: Behavior is controlled via a JSON configuration file.
 
@@ -48,6 +48,7 @@ AuthTransformer is a simple Go-based reverse proxy that injects authentication t
    ```
 
    - **integrations**: Defines proxy routes, rate limits and authentication methods. Secret references use the `env:` or KMS-prefixed formats described below.
+   - **google_oidc**: Outgoing auth plugin that retrieves an ID token from the GCP metadata server and sets it in the `Authorization` header for backend requests.
 
 3. **Running**
 

--- a/app/authplugins/outgoing/google_oidc.go
+++ b/app/authplugins/outgoing/google_oidc.go
@@ -1,0 +1,77 @@
+package outgoing
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/winhowes/AuthTransformer/app/authplugins"
+)
+
+// googleOIDCParams holds configuration for the Google OIDC plugin.
+type googleOIDCParams struct {
+	Audience string `json:"audience"`
+	Header   string `json:"header"`
+	Prefix   string `json:"prefix"`
+}
+
+// GoogleOIDC obtains an identity token from the GCP metadata server and sets it
+// on outgoing requests.
+type GoogleOIDC struct{}
+
+// MetadataHost is the base URL for the metadata server. It is overridden in tests.
+var MetadataHost = "http://metadata.google.internal"
+
+func (g *GoogleOIDC) Name() string { return "google_oidc" }
+
+func (g *GoogleOIDC) RequiredParams() []string {
+	return []string{"audience"}
+}
+
+func (g *GoogleOIDC) OptionalParams() []string { return []string{"header", "prefix"} }
+
+func (g *GoogleOIDC) ParseParams(m map[string]interface{}) (interface{}, error) {
+	p, err := authplugins.ParseParams[googleOIDCParams](m)
+	if err != nil {
+		return nil, err
+	}
+	if p.Audience == "" {
+		return nil, fmt.Errorf("missing audience")
+	}
+	if p.Header == "" {
+		p.Header = "Authorization"
+	}
+	if p.Prefix == "" {
+		p.Prefix = "Bearer "
+	}
+	return p, nil
+}
+
+func (g *GoogleOIDC) AddAuth(r *http.Request, params interface{}) {
+	cfg, ok := params.(*googleOIDCParams)
+	if !ok {
+		return
+	}
+	metaURL := fmt.Sprintf("%s/computeMetadata/v1/instance/service-accounts/default/identity?audience=%s", MetadataHost, url.QueryEscape(cfg.Audience))
+	req, err := http.NewRequest("GET", metaURL, nil)
+	if err != nil {
+		return
+	}
+	req.Header.Set("Metadata-Flavor", "Google")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return
+	}
+	token, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+	r.Header.Set(cfg.Header, cfg.Prefix+string(token))
+}
+
+func init() { authplugins.RegisterOutgoing(&GoogleOIDC{}) }

--- a/app/google_oidc_plugin_test.go
+++ b/app/google_oidc_plugin_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/winhowes/AuthTransformer/app/authplugins/outgoing"
+	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
+)
+
+func TestGoogleOIDCAddAuth(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Metadata-Flavor") != "Google" {
+			t.Errorf("missing metadata header")
+		}
+		if q := r.URL.Query().Get("audience"); q != "testaud" {
+			t.Errorf("unexpected audience %s", q)
+		}
+		fmt.Fprint(w, "tok123")
+	}))
+	defer ts.Close()
+
+	oldHost := outgoing.MetadataHost
+	outgoing.MetadataHost = ts.URL
+	defer func() { outgoing.MetadataHost = oldHost }()
+
+	p := outgoing.GoogleOIDC{}
+	cfg, err := p.ParseParams(map[string]interface{}{"audience": "testaud"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &http.Request{Header: http.Header{}}
+	p.AddAuth(r, cfg)
+	if got := r.Header.Get("Authorization"); got != "Bearer tok123" {
+		t.Fatalf("expected 'Bearer tok123', got %s", got)
+	}
+}
+
+func TestGoogleOIDCDefaults(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "tok")
+	}))
+	defer ts.Close()
+
+	oldHost := outgoing.MetadataHost
+	outgoing.MetadataHost = ts.URL
+	defer func() { outgoing.MetadataHost = oldHost }()
+
+	p := outgoing.GoogleOIDC{}
+	cfg, err := p.ParseParams(map[string]interface{}{"audience": "aud"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &http.Request{Header: http.Header{}}
+	p.AddAuth(r, cfg)
+	if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+		t.Fatalf("unexpected header %s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a new outgoing auth plugin that fetches ID tokens from the GCP metadata server
- document the new plugin in README
- test Google OIDC auth plugin behaviour

## Testing
- `go test ./...`
- `go test -run GoogleOIDC ./app -v`
