### PR TITLE
Add strict JSON decoding for config

### DIFF
--- a/app/config_test.go
+++ b/app/config_test.go
@@ -30,3 +30,20 @@ func TestLoadConfigInvalidJSON(t *testing.T) {
 		t.Fatal("expected JSON unmarshal error")
 	}
 }
+
+func TestLoadConfigUnknownField(t *testing.T) {
+	tmp, err := ioutil.TempFile("", "unknown*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.WriteString("{\"bogus\": 1}"); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+
+	if _, err := loadConfig(tmp.Name()); err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+}

--- a/app/main.go
+++ b/app/main.go
@@ -24,14 +24,21 @@ type Config struct {
 var debug = flag.Bool("debug", false, "enable debug mode")
 
 func loadConfig(filename string) (*Config, error) {
-	data, err := os.ReadFile(filename)
+	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
+
+	dec := json.NewDecoder(f)
+	dec.DisallowUnknownFields()
 
 	var config Config
-	err = json.Unmarshal(data, &config)
-	return &config, err
+	if err := dec.Decode(&config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
 }
 
 type RateLimiter struct {


### PR DESCRIPTION
## Summary
- loadConfig now uses json.Decoder with DisallowUnknownFields to reject unknown keys
- added test verifying that unknown configuration keys return an error

## Testing
- `go test ./...`