### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+# Build stage
+FROM golang:1.24.3-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o authtransformer ./app
+
+# Runtime stage
+FROM alpine:3.19
+WORKDIR /app
+COPY --from=build /src/authtransformer .
+COPY app/config.json ./config.json
+EXPOSE 8080
+CMD ["./authtransformer"]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ Use the Go toolchain to run the unit tests from the repository root:
 GO111MODULE=off go test ./...
 ```
 
+## Docker
+
+Build the container image:
+
+```bash
+docker build -t authtransformer .
+```
+
+Run the image exposing port 8080:
+
+```bash
+docker run -p 8080:8080 authtransformer
+```
+
 ## Logging
 
 AuthTransformer writes log messages to standard output. Each request generates an entry showing the HTTP method, host, path and remote address. Authentication failures and rate limiting events are also logged. The logger is configured with Go's standard time-prefixed format.


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile to build and run the Go app
- document how to build and run the container

## Testing
- `go test ./...`
