### PR TITLE
Add vet and optional linting to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,5 +14,14 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.24.3'
+      - name: Vet code
+        run: go vet ./...
+      - name: Lint (optional)
+        run: |
+          if command -v golangci-lint >/dev/null 2>&1; then
+            golangci-lint run
+          else
+            echo "golangci-lint not installed, skipping"
+          fi
       - name: Run tests
         run: go test ./...

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ AuthTransformer is a simple Go-based reverse proxy that injects authentication t
 - **Rate Limiting**: Limits the number of requests per caller and per host within a rolling window.
 - **Configuration Driven**: Behavior is controlled via a JSON configuration file.
 
+## Development Requirements
+
+- [Go](https://golang.org/doc/install) 1.24 or newer.
+- [`golangci-lint`](https://github.com/golangci/golangci-lint) (optional) for running lint checks.
+
 ## Getting Started
 
 1. **Build or Run**
@@ -56,10 +61,17 @@ AuthTransformer is a simple Go-based reverse proxy that injects authentication t
 
 ## Running Tests
 
-Use the Go toolchain to run the unit tests from the repository root:
+Use the Go toolchain to vet and test the code:
 
 ```bash
-GO111MODULE=off go test ./...
+go vet ./...
+go test ./...
+```
+
+If you have [`golangci-lint`](https://github.com/golangci/golangci-lint) installed you can also run:
+
+```bash
+golangci-lint run
 ```
 
 ## Logging


### PR DESCRIPTION
## Summary
- update workflow to run `go vet ./...` and optionally `golangci-lint run`
- document Go and golangci-lint tooling
- document vet and lint commands when running tests

## Testing
- `go vet ./...`
- `go test ./...`
