### PR TITLE
Add caller allowlist feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ AuthTransformer is a simple Go-based reverse proxy that injects authentication t
 - **Reverse Proxy**: Forwards incoming HTTP requests to a target backend based on the requested host or `X-AT-Int` header.
 - **Pluggable Authentication**: Supports "basic", "token" and Google OIDC authentication types with room for extension.=======
 - **Rate Limiting**: Limits the number of requests per caller and per host within a rolling window.
+- **Allowlist**: Integrations can restrict specific callers to particular paths, methods and required parameters.
 - **Configuration Driven**: Behavior is controlled via a JSON configuration file.
 - **Clean Shutdown**: On SIGINT or SIGTERM the server and rate limiters are gracefully stopped.
 
@@ -45,13 +46,21 @@ AuthTransformer is a simple Go-based reverse proxy that injects authentication t
               "incoming_auth": [
                   {"type": "token", "params": {"secrets": ["env:IN_TOKEN"], "header": "X-Auth"}}
               ],
-              "outgoing_auth": [
-                  {"type": "token", "params": {"secrets": ["env:OUT_TOKEN"], "header": "X-Auth"}}
-              ]
-           }
-       ]
-   }
-   ```
+                "outgoing_auth": [
+                    {"type": "token", "params": {"secrets": ["env:OUT_TOKEN"], "header": "X-Auth"}}
+                ],
+                "allowlist": [
+                    {
+                        "id": "user-token",
+                        "rules": [
+                            {"path": "/allowed", "methods": {"GET": {}}}
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    ```
 
 
    - **integrations**: Defines proxy routes, rate limits and authentication methods. Secret references use the `env:` or KMS-prefixed formats described below.

--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+)
+
+// matchPath checks whether the request path matches the pattern. '*' matches a
+// single path segment while '**' matches any remaining segments.
+func matchPath(pattern, p string) bool {
+	pattSegs := strings.Split(strings.Trim(path.Clean(pattern), "/"), "/")
+	segs := strings.Split(strings.Trim(path.Clean(p), "/"), "/")
+	return matchSegments(pattSegs, segs)
+}
+
+func matchSegments(pattern, path []string) bool {
+	if len(pattern) == 0 {
+		return len(path) == 0
+	}
+	if pattern[0] == "**" {
+		return true
+	}
+	if len(path) == 0 {
+		return false
+	}
+	if pattern[0] == "*" || pattern[0] == path[0] {
+		return matchSegments(pattern[1:], path[1:])
+	}
+	return false
+}
+
+// validateRequest checks headers and body according to the request constraint.
+func validateRequest(r *http.Request, c RequestConstraint) bool {
+	for _, h := range c.Headers {
+		if r.Header.Get(h) == "" {
+			return false
+		}
+	}
+	if len(c.Body) == 0 {
+		return true
+	}
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		return false
+	}
+	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	ct := r.Header.Get("Content-Type")
+	if strings.Contains(ct, "application/json") {
+		var data map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &data); err != nil {
+			return false
+		}
+		return matchBodyMap(data, c.Body)
+	}
+	if strings.Contains(ct, "application/x-www-form-urlencoded") {
+		vals, err := url.ParseQuery(string(bodyBytes))
+		if err != nil {
+			return false
+		}
+		return matchForm(vals, c.Body)
+	}
+	// unsupported content type
+	return false
+}
+
+func matchForm(vals url.Values, rule map[string]interface{}) bool {
+	for k, v := range rule {
+		if vals.Get(k) == "" {
+			return false
+		}
+		if arr, ok := v.([]interface{}); ok {
+			present := vals[k]
+			for _, want := range arr {
+				s, ok := want.(string)
+				if !ok {
+					return false
+				}
+				found := false
+				for _, p := range present {
+					if p == s {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+func matchBodyMap(data map[string]interface{}, rule map[string]interface{}) bool {
+	for k, v := range rule {
+		dv, ok := data[k]
+		if !ok {
+			return false
+		}
+		switch rv := v.(type) {
+		case []interface{}:
+			arr, ok := dv.([]interface{})
+			if !ok {
+				return false
+			}
+			for _, want := range rv {
+				found := false
+				for _, elem := range arr {
+					if elem == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return false
+				}
+			}
+		default:
+			if dv != v {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// findConstraint returns the RequestConstraint for the given caller, path and
+// method if one exists.
+func findConstraint(i *Integration, callerID, pth, method string) (RequestConstraint, bool) {
+	for _, c := range i.AllowedCallers {
+		if c.ID != callerID {
+			continue
+		}
+		for _, r := range c.Rules {
+			if matchPath(r.Path, pth) {
+				if m, ok := r.Methods[method]; ok {
+					return m, true
+				}
+			}
+		}
+	}
+	return RequestConstraint{}, false
+}

--- a/app/allowlist_test.go
+++ b/app/allowlist_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	_ "github.com/winhowes/AuthTransformer/app/authplugins/incoming"
+	_ "github.com/winhowes/AuthTransformer/app/authplugins/outgoing"
+	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
+)
+
+func TestAllowlist(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	t.Setenv("TOK", "secret")
+	integ := Integration{
+		Name:         "allowlist",
+		Destination:  backend.URL,
+		InRateLimit:  10,
+		OutRateLimit: 10,
+		IncomingAuth: []AuthPluginConfig{{Type: "token", Params: map[string]interface{}{"secrets": []string{"env:TOK"}, "header": "X-Auth"}}},
+		AllowedCallers: []CallerConfig{
+			{ID: "secret", Rules: []CallRule{{Path: "/allowed", Methods: map[string]RequestConstraint{"GET": {}}}}},
+		},
+	}
+	if err := AddIntegration(&integ); err != nil {
+		t.Fatalf("failed to add integration: %v", err)
+	}
+	t.Cleanup(func() {
+		integ.inLimiter.Stop()
+		integ.outLimiter.Stop()
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://allowlist/allowed", nil)
+	req.Host = "allowlist"
+	req.Header.Set("X-Auth", "secret")
+	rr := httptest.NewRecorder()
+	proxyHandler(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "http://allowlist/forbidden", nil)
+	req2.Host = "allowlist"
+	req2.Header.Set("X-Auth", "secret")
+	rr2 := httptest.NewRecorder()
+	proxyHandler(rr2, req2)
+	if rr2.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rr2.Code)
+	}
+}

--- a/app/authplugins/incoming/token.go
+++ b/app/authplugins/incoming/token.go
@@ -50,4 +50,18 @@ func (t *TokenAuth) Authenticate(r *http.Request, p interface{}) bool {
 	return false
 }
 
+// Identify returns the raw token value provided by the caller. It is used as a
+// caller ID for allowlist checks.
+func (t *TokenAuth) Identify(r *http.Request, p interface{}) (string, bool) {
+	cfg, ok := p.(*params)
+	if !ok {
+		return "", false
+	}
+	tokenValue := strings.TrimPrefix(r.Header.Get(cfg.Header), cfg.Prefix)
+	if tokenValue == "" {
+		return "", false
+	}
+	return tokenValue, true
+}
+
 func init() { authplugins.RegisterIncoming(&TokenAuth{}) }

--- a/app/authplugins/registry.go
+++ b/app/authplugins/registry.go
@@ -14,6 +14,12 @@ type IncomingAuthPlugin interface {
 	OptionalParams() []string
 }
 
+// Identifier is implemented by incoming auth plugins that can derive a caller
+// identifier from the request. The identifier is used by allowlist checks.
+type Identifier interface {
+	Identify(r *http.Request, params interface{}) (string, bool)
+}
+
 // OutgoingAuthPlugin applies authentication to outbound requests.
 // OutgoingAuthPlugin applies authentication to outbound requests.
 type OutgoingAuthPlugin interface {

--- a/app/integration.go
+++ b/app/integration.go
@@ -111,14 +111,34 @@ type AuthPluginConfig struct {
 	parsed interface{}
 }
 
+// CallerConfig defines allowed paths and methods for a specific caller
+// identifier.
+type CallerConfig struct {
+	ID    string     `json:"id"`
+	Rules []CallRule `json:"rules"`
+}
+
+// CallRule ties a path pattern to method-specific constraints.
+type CallRule struct {
+	Path    string                       `json:"path"`
+	Methods map[string]RequestConstraint `json:"methods"`
+}
+
+// RequestConstraint lists required headers and body parameters.
+type RequestConstraint struct {
+	Headers []string               `json:"headers"`
+	Body    map[string]interface{} `json:"body"`
+}
+
 // Integration represents a configured proxy integration.
 type Integration struct {
-	Name         string             `json:"name"`
-	Destination  string             `json:"destination"`
-	InRateLimit  int                `json:"in_rate_limit"`
-	OutRateLimit int                `json:"out_rate_limit"`
-	IncomingAuth []AuthPluginConfig `json:"incoming_auth"`
-	OutgoingAuth []AuthPluginConfig `json:"outgoing_auth"`
+	Name           string             `json:"name"`
+	Destination    string             `json:"destination"`
+	InRateLimit    int                `json:"in_rate_limit"`
+	OutRateLimit   int                `json:"out_rate_limit"`
+	IncomingAuth   []AuthPluginConfig `json:"incoming_auth"`
+	OutgoingAuth   []AuthPluginConfig `json:"outgoing_auth"`
+	AllowedCallers []CallerConfig     `json:"allowlist"`
 
 	inLimiter  *RateLimiter
 	outLimiter *RateLimiter


### PR DESCRIPTION
## Summary
- add caller allowlist structs to Integration
- support caller ID from incoming auth plugins
- implement allowlist matching and validation
- expose Identify method for token auth plugin
- document allowlist usage
- test allowlist behaviour

## Testing
- `go test ./...`