### PR TITLE
Reorganize auth plugins by plugin name

### DIFF
--- a/app/allowlist_test.go
+++ b/app/allowlist_test.go
@@ -5,8 +5,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	_ "github.com/winhowes/AuthTransformer/app/authplugins/incoming"
-	_ "github.com/winhowes/AuthTransformer/app/authplugins/outgoing"
+	_ "github.com/winhowes/AuthTransformer/app/authplugins/basic"
+	_ "github.com/winhowes/AuthTransformer/app/authplugins/google_oidc"
+	_ "github.com/winhowes/AuthTransformer/app/authplugins/token"
 	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
 )
 

--- a/app/authplugins/basic/basic_test.go
+++ b/app/authplugins/basic/basic_test.go
@@ -1,18 +1,16 @@
-package main
+package basic
 
 import (
 	"encoding/base64"
 	"net/http"
 	"testing"
 
-	"github.com/winhowes/AuthTransformer/app/authplugins/incoming"
-	"github.com/winhowes/AuthTransformer/app/authplugins/outgoing"
 	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
 )
 
 func TestBasicOutgoingAddAuth(t *testing.T) {
 	r := &http.Request{Header: http.Header{}}
-	p := outgoing.BasicAuthOut{}
+	p := BasicAuthOut{}
 	t.Setenv("CREDS", "user:pass")
 	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:CREDS"}})
 	if err != nil {
@@ -28,7 +26,7 @@ func TestBasicOutgoingAddAuth(t *testing.T) {
 func TestBasicIncomingAuth(t *testing.T) {
 	cred := base64.StdEncoding.EncodeToString([]byte("user:pass"))
 	r := &http.Request{Header: http.Header{"Authorization": []string{"Basic " + cred}}}
-	p := incoming.BasicAuth{}
+	p := BasicAuth{}
 	t.Setenv("CREDS", "user:pass")
 	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:CREDS"}})
 	if err != nil {
@@ -42,7 +40,7 @@ func TestBasicIncomingAuth(t *testing.T) {
 func TestBasicIncomingAuthFail(t *testing.T) {
 	cred := base64.StdEncoding.EncodeToString([]byte("user:wrong"))
 	r := &http.Request{Header: http.Header{"Authorization": []string{"Basic " + cred}}}
-	p := incoming.BasicAuth{}
+	p := BasicAuth{}
 	t.Setenv("CREDS", "user:pass")
 	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:CREDS"}})
 	if err != nil {
@@ -54,8 +52,8 @@ func TestBasicIncomingAuthFail(t *testing.T) {
 }
 
 func TestBasicPluginOptionalParams(t *testing.T) {
-	in := incoming.BasicAuth{}
-	out := outgoing.BasicAuthOut{}
+	in := BasicAuth{}
+	out := BasicAuthOut{}
 	if got := in.OptionalParams(); len(got) != 2 || got[0] != "header" || got[1] != "prefix" {
 		t.Fatalf("unexpected optional params: %v", got)
 	}

--- a/app/authplugins/basic/incoming.go
+++ b/app/authplugins/basic/incoming.go
@@ -1,4 +1,4 @@
-package incoming
+package basic
 
 import (
 	"encoding/base64"
@@ -11,7 +11,7 @@ import (
 )
 
 // BasicAuth validates HTTP Basic credentials from the request header.
-type basicParams struct {
+type inParams struct {
 	Secrets []string `json:"secrets"`
 	Header  string   `json:"header"`
 	Prefix  string   `json:"prefix"`
@@ -24,7 +24,7 @@ func (b *BasicAuth) RequiredParams() []string { return []string{"secrets"} }
 func (b *BasicAuth) OptionalParams() []string { return []string{"header", "prefix"} }
 
 func (b *BasicAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
-	p, err := authplugins.ParseParams[basicParams](m)
+	p, err := authplugins.ParseParams[inParams](m)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func (b *BasicAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
 }
 
 func (b *BasicAuth) Authenticate(r *http.Request, p interface{}) bool {
-	cfg, ok := p.(*basicParams)
+	cfg, ok := p.(*inParams)
 	if !ok {
 		return false
 	}

--- a/app/authplugins/basic/outgoing.go
+++ b/app/authplugins/basic/outgoing.go
@@ -1,4 +1,4 @@
-package outgoing
+package basic
 
 import (
 	"encoding/base64"
@@ -10,7 +10,7 @@ import (
 )
 
 // BasicAuthOut sets HTTP Basic credentials on outbound requests.
-type basicParams struct {
+type outParams struct {
 	Secrets []string `json:"secrets"`
 	Header  string   `json:"header"`
 	Prefix  string   `json:"prefix"`
@@ -23,7 +23,7 @@ func (b *BasicAuthOut) RequiredParams() []string { return []string{"secrets"} }
 func (b *BasicAuthOut) OptionalParams() []string { return []string{"header", "prefix"} }
 
 func (b *BasicAuthOut) ParseParams(m map[string]interface{}) (interface{}, error) {
-	p, err := authplugins.ParseParams[basicParams](m)
+	p, err := authplugins.ParseParams[outParams](m)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func (b *BasicAuthOut) ParseParams(m map[string]interface{}) (interface{}, error
 }
 
 func (b *BasicAuthOut) AddAuth(r *http.Request, p interface{}) {
-	cfg, ok := p.(*basicParams)
+	cfg, ok := p.(*outParams)
 	if !ok || len(cfg.Secrets) == 0 {
 		return
 	}

--- a/app/authplugins/google_oidc/google_oidc_test.go
+++ b/app/authplugins/google_oidc/google_oidc_test.go
@@ -1,4 +1,4 @@
-package main
+package googleoidc
 
 import (
 	"fmt"
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/winhowes/AuthTransformer/app/authplugins/outgoing"
 	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
 )
 
@@ -22,11 +21,11 @@ func TestGoogleOIDCAddAuth(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	oldHost := outgoing.MetadataHost
-	outgoing.MetadataHost = ts.URL
-	defer func() { outgoing.MetadataHost = oldHost }()
+	oldHost := MetadataHost
+	MetadataHost = ts.URL
+	defer func() { MetadataHost = oldHost }()
 
-	p := outgoing.GoogleOIDC{}
+	p := GoogleOIDC{}
 	cfg, err := p.ParseParams(map[string]interface{}{"audience": "testaud"})
 	if err != nil {
 		t.Fatal(err)
@@ -45,11 +44,11 @@ func TestGoogleOIDCDefaults(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	oldHost := outgoing.MetadataHost
-	outgoing.MetadataHost = ts.URL
-	defer func() { outgoing.MetadataHost = oldHost }()
+	oldHost := MetadataHost
+	MetadataHost = ts.URL
+	defer func() { MetadataHost = oldHost }()
 
-	p := outgoing.GoogleOIDC{}
+	p := GoogleOIDC{}
 	cfg, err := p.ParseParams(map[string]interface{}{"audience": "aud"})
 	if err != nil {
 		t.Fatal(err)

--- a/app/authplugins/google_oidc/outgoing.go
+++ b/app/authplugins/google_oidc/outgoing.go
@@ -1,4 +1,4 @@
-package outgoing
+package googleoidc
 
 import (
 	"fmt"

--- a/app/authplugins/token/incoming.go
+++ b/app/authplugins/token/incoming.go
@@ -1,4 +1,4 @@
-package incoming
+package token
 
 import (
 	"fmt"
@@ -10,7 +10,7 @@ import (
 )
 
 // TokenAuth checks that the caller supplied one of the configured tokens.
-type params struct {
+type inParams struct {
 	Secrets []string `json:"secrets"`
 	Header  string   `json:"header"`
 	Prefix  string   `json:"prefix"`
@@ -25,7 +25,7 @@ func (t *TokenAuth) RequiredParams() []string {
 func (t *TokenAuth) OptionalParams() []string { return []string{"prefix"} }
 
 func (t *TokenAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
-	p, err := authplugins.ParseParams[params](m)
+	p, err := authplugins.ParseParams[inParams](m)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +36,7 @@ func (t *TokenAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
 }
 
 func (t *TokenAuth) Authenticate(r *http.Request, p interface{}) bool {
-	cfg, ok := p.(*params)
+	cfg, ok := p.(*inParams)
 	if !ok {
 		return false
 	}
@@ -53,7 +53,7 @@ func (t *TokenAuth) Authenticate(r *http.Request, p interface{}) bool {
 // Identify returns the raw token value provided by the caller. It is used as a
 // caller ID for allowlist checks.
 func (t *TokenAuth) Identify(r *http.Request, p interface{}) (string, bool) {
-	cfg, ok := p.(*params)
+	cfg, ok := p.(*inParams)
 	if !ok {
 		return "", false
 	}

--- a/app/authplugins/token/outgoing.go
+++ b/app/authplugins/token/outgoing.go
@@ -1,4 +1,4 @@
-package outgoing
+package token
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 )
 
 // TokenAuthOut adds a token header to outbound requests.
-type params struct {
+type outParams struct {
 	Secrets []string `json:"secrets"`
 	Header  string   `json:"header"`
 	Prefix  string   `json:"prefix"`
@@ -24,7 +24,7 @@ func (t *TokenAuthOut) RequiredParams() []string {
 func (t *TokenAuthOut) OptionalParams() []string { return []string{"prefix"} }
 
 func (t *TokenAuthOut) ParseParams(m map[string]interface{}) (interface{}, error) {
-	p, err := authplugins.ParseParams[params](m)
+	p, err := authplugins.ParseParams[outParams](m)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func (t *TokenAuthOut) ParseParams(m map[string]interface{}) (interface{}, error
 }
 
 func (t *TokenAuthOut) AddAuth(r *http.Request, p interface{}) {
-	cfg, ok := p.(*params)
+	cfg, ok := p.(*outParams)
 	if !ok || len(cfg.Secrets) == 0 {
 		return
 	}

--- a/app/authplugins/token/token_test.go
+++ b/app/authplugins/token/token_test.go
@@ -1,17 +1,15 @@
-package main
+package token
 
 import (
 	"net/http"
 	"testing"
 
-	"github.com/winhowes/AuthTransformer/app/authplugins/incoming"
-	"github.com/winhowes/AuthTransformer/app/authplugins/outgoing"
 	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
 )
 
 func TestTokenOutgoingPrefix(t *testing.T) {
 	r := &http.Request{Header: http.Header{}}
-	p := outgoing.TokenAuthOut{}
+	p := TokenAuthOut{}
 	t.Setenv("TOK", "secret")
 	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:TOK"}, "header": "Authorization", "prefix": "Bearer "})
 	if err != nil {
@@ -25,7 +23,7 @@ func TestTokenOutgoingPrefix(t *testing.T) {
 
 func TestTokenIncomingPrefix(t *testing.T) {
 	r := &http.Request{Header: http.Header{"Authorization": []string{"Bearer secret"}}}
-	p := incoming.TokenAuth{}
+	p := TokenAuth{}
 	t.Setenv("TOK", "secret")
 	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:TOK"}, "header": "Authorization", "prefix": "Bearer "})
 	if err != nil {
@@ -38,7 +36,7 @@ func TestTokenIncomingPrefix(t *testing.T) {
 
 func TestTokenIncomingPrefixMismatch(t *testing.T) {
 	r := &http.Request{Header: http.Header{"Authorization": []string{"Bearer secret"}}}
-	p := incoming.TokenAuth{}
+	p := TokenAuth{}
 	t.Setenv("TOK", "secret")
 	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:TOK"}, "header": "Authorization"})
 	if err != nil {
@@ -50,8 +48,8 @@ func TestTokenIncomingPrefixMismatch(t *testing.T) {
 }
 
 func TestTokenPluginOptionalParams(t *testing.T) {
-	in := incoming.TokenAuth{}
-	out := outgoing.TokenAuthOut{}
+	in := TokenAuth{}
+	out := TokenAuthOut{}
 	if got := in.OptionalParams(); len(got) != 1 || got[0] != "prefix" {
 		t.Fatalf("unexpected optional params: %v", got)
 	}

--- a/app/integration_test.go
+++ b/app/integration_test.go
@@ -3,8 +3,9 @@ package main
 import (
 	"testing"
 
-	_ "github.com/winhowes/AuthTransformer/app/authplugins/incoming"
-	_ "github.com/winhowes/AuthTransformer/app/authplugins/outgoing"
+	_ "github.com/winhowes/AuthTransformer/app/authplugins/basic"
+	_ "github.com/winhowes/AuthTransformer/app/authplugins/google_oidc"
+	_ "github.com/winhowes/AuthTransformer/app/authplugins/token"
 	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
 )
 

--- a/app/main.go
+++ b/app/main.go
@@ -16,8 +16,9 @@ import (
 	"time"
 
 	"github.com/winhowes/AuthTransformer/app/authplugins"
-	_ "github.com/winhowes/AuthTransformer/app/authplugins/incoming"
-	_ "github.com/winhowes/AuthTransformer/app/authplugins/outgoing"
+	_ "github.com/winhowes/AuthTransformer/app/authplugins/basic"
+	_ "github.com/winhowes/AuthTransformer/app/authplugins/google_oidc"
+	_ "github.com/winhowes/AuthTransformer/app/authplugins/token"
 	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
 )
 


### PR DESCRIPTION
## Summary
- move outgoing & incoming plugin impls into per-plugin folders
- relocate plugin tests alongside their code
- update imports to use the new plugin packages

## Testing
- `go test ./...`