### PR TITLE
Load allowlists from external file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,30 +37,40 @@ AuthTransformer is a simple Go-based reverse proxy that injects authentication t
    
    ```json
    {
-       "integrations": [
-           {
-               "name": "example",
-               "destination": "http://backend.example.com",
-               "in_rate_limit": 100,
-               "out_rate_limit": 1000,
-              "incoming_auth": [
-                  {"type": "token", "params": {"secrets": ["env:IN_TOKEN"], "header": "X-Auth"}}
-              ],
+        "integrations": [
+            {
+                "name": "example",
+                "destination": "http://backend.example.com",
+                "in_rate_limit": 100,
+                "out_rate_limit": 1000,
+               "incoming_auth": [
+                   {"type": "token", "params": {"secrets": ["env:IN_TOKEN"], "header": "X-Auth"}}
+               ],
                 "outgoing_auth": [
                     {"type": "token", "params": {"secrets": ["env:OUT_TOKEN"], "header": "X-Auth"}}
-                ],
-                "allowlist": [
-                    {
-                        "id": "user-token",
-                        "rules": [
-                            {"path": "/allowed", "methods": {"GET": {}}}
-                        ]
-                    }
                 ]
             }
         ]
     }
     ```
+
+   The allowlist configuration lives in a separate `allowlist.json` file:
+
+   ```json
+   [
+       {
+           "integration": "example",
+           "callers": [
+               {
+                   "id": "user-token",
+                   "rules": [
+                       {"path": "/allowed", "methods": {"GET": {}}}
+                   ]
+               }
+           ]
+       }
+   ]
+   ```
 
 
    - **integrations**: Defines proxy routes, rate limits and authentication methods. Secret references use the `env:` or KMS-prefixed formats described below.
@@ -77,7 +87,7 @@ AuthTransformer is a simple Go-based reverse proxy that injects authentication t
 
 3. **Running**
 
-   The listen address can be configured with the `-addr` flag. By default the server listens on `:8080`. Incoming requests are matched against the `X-AT-Int` header, if present, or otherwise the host header to determine the route and associated authentication plugin. Use `-disable_x_at_int` to ignore the header entirely or `-x_at_int_host` to only respect the header when a specific host is requested.
+   The listen address can be configured with the `-addr` flag. By default the server listens on `:8080`. Incoming requests are matched against the `X-AT-Int` header, if present, or otherwise the host header to determine the route and associated authentication plugin. Use `-disable_x_at_int` to ignore the header entirely or `-x_at_int_host` to only respect the header when a specific host is requested. The allowlist file can be specified with `-allowlist`; it defaults to `allowlist.json`.
 
 4. **Run Locally**
 
@@ -114,7 +124,7 @@ AuthTransformer is a simple Go-based reverse proxy that injects authentication t
    ```bash
    export IN_TOKEN=secret-in
    export OUT_TOKEN=secret-out
-   go run ./app
+   go run ./app -allowlist allowlist.json
    ```
 
    In another terminal, call the proxy using the integration name as the Host header:

--- a/app/allowlist.json
+++ b/app/allowlist.json
@@ -1,0 +1,6 @@
+[
+    {
+        "integration": "example",
+        "callers": []
+    }
+]

--- a/app/allowlist_file_test.go
+++ b/app/allowlist_file_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestLoadAllowlistsInvalidFile(t *testing.T) {
+	_, err := loadAllowlists("nonexistent.json")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestLoadAllowlistsInvalidJSON(t *testing.T) {
+	tmp, err := ioutil.TempFile("", "bad*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.WriteString("{invalid}"); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+
+	_, err = loadAllowlists(tmp.Name())
+	if err == nil {
+		t.Fatal("expected JSON unmarshal error")
+	}
+}
+
+func TestLoadAllowlistsUnknownField(t *testing.T) {
+	tmp, err := ioutil.TempFile("", "unknown*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.WriteString("[{\"bogus\":1}]"); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+
+	if _, err := loadAllowlists(tmp.Name()); err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+}

--- a/app/allowlist_test.go
+++ b/app/allowlist_test.go
@@ -23,13 +23,13 @@ func TestAllowlist(t *testing.T) {
 		InRateLimit:  10,
 		OutRateLimit: 10,
 		IncomingAuth: []AuthPluginConfig{{Type: "token", Params: map[string]interface{}{"secrets": []string{"env:TOK"}, "header": "X-Auth"}}},
-		AllowedCallers: []CallerConfig{
-			{ID: "secret", Rules: []CallRule{{Path: "/allowed", Methods: map[string]RequestConstraint{"GET": {}}}}},
-		},
 	}
 	if err := AddIntegration(&integ); err != nil {
 		t.Fatalf("failed to add integration: %v", err)
 	}
+	SetAllowlist("allowlist", []CallerConfig{
+		{ID: "secret", Rules: []CallRule{{Path: "/allowed", Methods: map[string]RequestConstraint{"GET": {}}}}},
+	})
 	t.Cleanup(func() {
 		integ.inLimiter.Stop()
 		integ.outLimiter.Stop()

--- a/app/integration.go
+++ b/app/integration.go
@@ -132,13 +132,12 @@ type RequestConstraint struct {
 
 // Integration represents a configured proxy integration.
 type Integration struct {
-	Name           string             `json:"name"`
-	Destination    string             `json:"destination"`
-	InRateLimit    int                `json:"in_rate_limit"`
-	OutRateLimit   int                `json:"out_rate_limit"`
-	IncomingAuth   []AuthPluginConfig `json:"incoming_auth"`
-	OutgoingAuth   []AuthPluginConfig `json:"outgoing_auth"`
-	AllowedCallers []CallerConfig     `json:"allowlist"`
+	Name         string             `json:"name"`
+	Destination  string             `json:"destination"`
+	InRateLimit  int                `json:"in_rate_limit"`
+	OutRateLimit int                `json:"out_rate_limit"`
+	IncomingAuth []AuthPluginConfig `json:"incoming_auth"`
+	OutgoingAuth []AuthPluginConfig `json:"outgoing_auth"`
 
 	inLimiter  *RateLimiter
 	outLimiter *RateLimiter

--- a/app/main.go
+++ b/app/main.go
@@ -21,14 +21,38 @@ import (
 	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
 )
 
+type AllowlistEntry struct {
+	Integration string         `json:"integration"`
+	Callers     []CallerConfig `json:"callers"`
+}
+
 type Config struct {
 	Integrations []Integration `json:"integrations"`
+}
+
+func loadAllowlists(filename string) ([]AllowlistEntry, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	dec := json.NewDecoder(f)
+	dec.DisallowUnknownFields()
+
+	var entries []AllowlistEntry
+	if err := dec.Decode(&entries); err != nil {
+		return nil, err
+	}
+
+	return entries, nil
 }
 
 var debug = flag.Bool("debug", false, "enable debug mode")
 var disableXATInt = flag.Bool("disable_x_at_int", false, "ignore X-AT-Int header for routing")
 var xAtIntHost = flag.String("x_at_int_host", "", "only respect X-AT-Int header when request Host matches this value")
 var addr = flag.String("addr", ":8080", "listen address")
+var allowlistFile = flag.String("allowlist", "allowlist.json", "path to allowlist configuration")
 
 func loadConfig(filename string) (*Config, error) {
 	f, err := os.Open(filename)
@@ -167,7 +191,8 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(integ.AllowedCallers) > 0 {
+	callers := GetAllowlist(integ.Name)
+	if len(callers) > 0 {
 		cons, ok := findConstraint(integ, callerID, r.URL.Path, r.Method)
 		if !ok {
 			http.Error(w, "Forbidden", http.StatusForbidden)
@@ -208,6 +233,14 @@ func main() {
 		if err := AddIntegration(&config.Integrations[i]); err != nil {
 			log.Fatalf("failed to load integration %s: %v", config.Integrations[i].Name, err)
 		}
+	}
+
+	entries, err := loadAllowlists(*allowlistFile)
+	if err != nil && !os.IsNotExist(err) {
+		log.Fatalf("failed to load allowlist: %v", err)
+	}
+	for _, al := range entries {
+		SetAllowlist(al.Integration, al.Callers)
 	}
 
 	// Include timestamps in log output


### PR DESCRIPTION
## Summary
- move allowlist configuration into its own JSON file
- add `loadAllowlists` helper and `-allowlist` flag
- update proxy setup to read allowlist entries from the file
- document new file in README and provide sample config
- test allowlist loader

## Testing
- `go vet ./...`
- `go test ./...`
