### PR TITLE
Improve docs and allowlist tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,43 @@ AuthTransformer is a simple Go-based reverse proxy that injects authentication t
                }
            ]
        }
-   ]
-   ```
+  ]
+  ```
+
+### Allowlist Rules
+
+Each caller entry lists path patterns and method constraints. `*` matches a
+single path segment while `**` matches any remaining segments. Header names are
+listed under `headers` and required body fields under `body`.
+
+Example rule requiring an `X-Token` header and a JSON field:
+
+```json
+{
+  "path": "/api/**",
+  "methods": {
+    "POST": {
+      "headers": ["X-Token"],
+      "body": {"action": "create"}
+    }
+  }
+}
+```
+
+For `application/x-www-form-urlencoded` requests the `body` keys refer to form
+fields and may list required values:
+
+```json
+{
+  "path": "/submit",
+  "methods": {
+    "POST": {
+  "body": {"tag": ["a", "b"]}
+  }
+  }
+  }
+  ```
+
 
 
    - **integrations**: Defines proxy routes, rate limits and authentication methods. Secret references use the `env:` or KMS-prefixed formats described below.
@@ -85,6 +120,22 @@ AuthTransformer is a simple Go-based reverse proxy that injects authentication t
 | `aws`  | `AWS_KMS_KEY` | Base64 encoded 32 byte key used for decrypting `aws:` secrets. |
 | `azure`| `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` | Credentials for fetching `azure:` secrets from Key Vault. |
 | `gcp`  | _none_ | Uses the GCP metadata service for authentication when resolving `gcp:` secrets. |
+
+### Writing Plugins
+
+New functionality can be added without modifying the core server.
+
+**Auth plugins** live under `app/authplugins`. Implement the
+`IncomingAuthPlugin` or `OutgoingAuthPlugin` interface and call the appropriate
+`authplugins.RegisterIncoming` or `authplugins.RegisterOutgoing` function in an
+`init()` block.
+
+**Secret plugins** implement the `secrets.Plugin` interface in
+`app/secrets/plugins` and register themselves with `secrets.Register`.
+
+The CLI in `cmd/integrations` can be extended by creating a new helper in
+`cmd/integrations/plugins` that returns an `Integration` struct. Add a case to
+`cmd/integrations/main.go` so the CLI recognizes the new plugin name.
 
 3. **Running**
 
@@ -136,15 +187,25 @@ AuthTransformer is a simple Go-based reverse proxy that injects authentication t
 
 ## Integration CLI
 
-When run with the `-debug` flag the server exposes a `/integrations` endpoint for adding integrations. A helper CLI is available under `cmd/integrations` to create Slack or GitHub integrations with minimal flags.
+Start the server with `-debug` so the `/integrations` endpoint is available:
+
+```bash
+go run ./app -debug
+```
+
+Then run the CLI to POST a new integration configuration. The `-server` flag
+controls where the CLI sends the request (default `http://localhost:8080/integrations`).
 
 Add Slack:
 ```bash
-go run ./cmd/integrations slack -token env:SLACK_TOKEN -signing-secret env:SLACK_SIGNING
+go run ./cmd/integrations -server http://localhost:8080/integrations \
+  slack -token env:SLACK_TOKEN -signing-secret env:SLACK_SIGNING
 ```
+
 Add GitHub:
 ```bash
-go run ./cmd/integrations github -token env:GITHUB_TOKEN -webhook-secret env:GITHUB_SECRET
+go run ./cmd/integrations -server http://localhost:8080/integrations \
+  github -token env:GITHUB_TOKEN -webhook-secret env:GITHUB_SECRET
 ```
 
 ## Running Tests

--- a/app/allowlist_match_test.go
+++ b/app/allowlist_match_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// TestMatchPath verifies wildcard path matching
+func TestMatchPath(t *testing.T) {
+	cases := []struct {
+		patt string
+		path string
+		ok   bool
+	}{
+		{"/foo/*", "/foo/bar", true},
+		{"/foo/*", "/foo/bar/baz", false},
+		{"/foo/**", "/foo/bar/baz", true},
+		{"/bar/**", "/bar", true},
+		{"**", "/any/thing", true},
+	}
+	for _, c := range cases {
+		if got := matchPath(c.patt, c.path); got != c.ok {
+			t.Errorf("matchPath(%q,%q)=%v want %v", c.patt, c.path, got, c.ok)
+		}
+	}
+}
+
+// helper to build request with body preserved
+func newRequest(method, urlStr, ct string, body []byte) *http.Request {
+	r := httptest.NewRequest(method, urlStr, bytes.NewReader(body))
+	r.Header.Set("Content-Type", ct)
+	return r
+}
+
+func TestValidateRequestHeaders(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "http://x", nil)
+	r.Header.Set("X-Test", "val")
+	if !validateRequest(r, RequestConstraint{Headers: []string{"X-Test"}}) {
+		t.Fatal("expected header match")
+	}
+	r2 := httptest.NewRequest(http.MethodGet, "http://x", nil)
+	if validateRequest(r2, RequestConstraint{Headers: []string{"X-Test"}}) {
+		t.Fatal("expected failure without header")
+	}
+}
+
+func TestValidateRequestJSONBody(t *testing.T) {
+	body := []byte(`{"a":"b","arr":[1,2]}`)
+	r := newRequest(http.MethodPost, "http://x", "application/json", body)
+	cons := RequestConstraint{Body: map[string]interface{}{"a": "b", "arr": []interface{}{float64(1)}}}
+	if !validateRequest(r, cons) {
+		t.Fatal("expected body match")
+	}
+}
+
+func TestValidateRequestFormBody(t *testing.T) {
+	form := url.Values{"a": {"1", "3"}, "b": {"2"}}
+	r := newRequest(http.MethodPost, "http://x", "application/x-www-form-urlencoded", []byte(form.Encode()))
+	cons := RequestConstraint{Body: map[string]interface{}{"a": []interface{}{"1", "3"}, "b": "2"}}
+	if !validateRequest(r, cons) {
+		t.Fatal("expected form match")
+	}
+}
+
+func TestValidateRequestBodyMismatch(t *testing.T) {
+	body := []byte(`{"a":"x"}`)
+	r := newRequest(http.MethodPost, "http://x", "application/json", body)
+	cons := RequestConstraint{Body: map[string]interface{}{"a": "b"}}
+	if validateRequest(r, cons) {
+		t.Fatal("expected body mismatch to fail")
+	}
+}


### PR DESCRIPTION
## Summary
- document plugin creation steps
- add examples for allowlist path/header/body matching
- describe how to run the CLI to add integrations
- add tests for allowlist matching functions

## Testing
- `go vet ./...`
- `go test ./...`
