### PR TITLE
Use custom client for Google OIDC plugin

### DIFF
--- a/app/authplugins/google_oidc/google_oidc_test.go
+++ b/app/authplugins/google_oidc/google_oidc_test.go
@@ -24,6 +24,9 @@ func TestGoogleOIDCAddAuth(t *testing.T) {
 	oldHost := MetadataHost
 	MetadataHost = ts.URL
 	defer func() { MetadataHost = oldHost }()
+	oldClient := HTTPClient
+	HTTPClient = ts.Client()
+	defer func() { HTTPClient = oldClient }()
 
 	p := GoogleOIDC{}
 	cfg, err := p.ParseParams(map[string]interface{}{"audience": "testaud"})
@@ -47,6 +50,9 @@ func TestGoogleOIDCDefaults(t *testing.T) {
 	oldHost := MetadataHost
 	MetadataHost = ts.URL
 	defer func() { MetadataHost = oldHost }()
+	oldClient := HTTPClient
+	HTTPClient = ts.Client()
+	defer func() { HTTPClient = oldClient }()
 
 	p := GoogleOIDC{}
 	cfg, err := p.ParseParams(map[string]interface{}{"audience": "aud"})

--- a/app/authplugins/google_oidc/outgoing.go
+++ b/app/authplugins/google_oidc/outgoing.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/winhowes/AuthTransformer/app/authplugins"
 )
@@ -22,6 +23,9 @@ type GoogleOIDC struct{}
 
 // MetadataHost is the base URL for the metadata server. It is overridden in tests.
 var MetadataHost = "http://metadata.google.internal"
+
+// HTTPClient is used for metadata requests and can be overridden in tests.
+var HTTPClient = &http.Client{Timeout: 5 * time.Second}
 
 func (g *GoogleOIDC) Name() string { return "google_oidc" }
 
@@ -59,7 +63,7 @@ func (g *GoogleOIDC) AddAuth(r *http.Request, params interface{}) {
 		return
 	}
 	req.Header.Set("Metadata-Flavor", "Google")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := HTTPClient.Do(req)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Summary
- add an `http.Client` with a 5s timeout for the Google OIDC outgoing auth plugin
- use this client for metadata requests
- allow tests to override the client

## Testing
- `go test ./...`
