### PR TITLE
Add integration capabilities and allowlist CLI

### DIFF
--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -9,6 +9,8 @@ import (
 	"path"
 	"strings"
 	"sync"
+
+	integrationplugins "github.com/winhowes/AuthTransformer/app/integrationplugins"
 )
 
 var allowlists = struct {
@@ -18,6 +20,7 @@ var allowlists = struct {
 
 // SetAllowlist registers the caller allowlist for an integration.
 func SetAllowlist(name string, callers []CallerConfig) {
+	callers = integrationplugins.ExpandCapabilities(name, callers)
 	allowlists.Lock()
 	allowlists.m[name] = callers
 	allowlists.Unlock()

--- a/app/integration.go
+++ b/app/integration.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/winhowes/AuthTransformer/app/authplugins"
+	integrationplugins "github.com/winhowes/AuthTransformer/app/integrationplugins"
 	"github.com/winhowes/AuthTransformer/app/secrets"
 )
 
@@ -114,22 +115,9 @@ type AuthPluginConfig struct {
 
 // CallerConfig defines allowed paths and methods for a specific caller
 // identifier.
-type CallerConfig struct {
-	ID    string     `json:"id"`
-	Rules []CallRule `json:"rules"`
-}
-
-// CallRule ties a path pattern to method-specific constraints.
-type CallRule struct {
-	Path    string                       `json:"path"`
-	Methods map[string]RequestConstraint `json:"methods"`
-}
-
-// RequestConstraint lists required headers and body parameters.
-type RequestConstraint struct {
-	Headers []string               `json:"headers"`
-	Body    map[string]interface{} `json:"body"`
-}
+type CallerConfig = integrationplugins.CallerConfig
+type CallRule = integrationplugins.CallRule
+type RequestConstraint = integrationplugins.RequestConstraint
 
 // Integration represents a configured proxy integration.
 type Integration struct {

--- a/app/integrationplugins/github/capabilities.go
+++ b/app/integrationplugins/github/capabilities.go
@@ -1,0 +1,20 @@
+package github
+
+import "fmt"
+
+import integrationplugins "github.com/winhowes/AuthTransformer/app/integrationplugins"
+
+func init() {
+	integrationplugins.RegisterCapability("github", "comment", integrationplugins.CapabilitySpec{
+		Params: []string{"repo"},
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			repo, _ := p["repo"].(string)
+			if repo == "" {
+				return nil, fmt.Errorf("repo parameter required")
+			}
+			path := fmt.Sprintf("/repos/%s/issues/*/comments", repo)
+			rule := integrationplugins.CallRule{Path: path, Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+}

--- a/app/integrationplugins/registry.go
+++ b/app/integrationplugins/registry.go
@@ -1,0 +1,59 @@
+package integrationplugins
+
+// CapabilityConfig defines a named capability and optional parameters.
+type CapabilityConfig struct {
+	Name   string                 `json:"name"`
+	Params map[string]interface{} `json:"params"`
+}
+
+// CapabilitySpec converts capability params into call rules.
+type CapabilitySpec struct {
+	Params   []string
+	Generate func(map[string]interface{}) ([]CallRule, error)
+}
+
+var capabilityRegistry = map[string]map[string]CapabilitySpec{}
+
+func RegisterCapability(integration, name string, spec CapabilitySpec) {
+	if capabilityRegistry[integration] == nil {
+		capabilityRegistry[integration] = map[string]CapabilitySpec{}
+	}
+	capabilityRegistry[integration][name] = spec
+}
+
+func getCapability(integration, name string) (CapabilitySpec, bool) {
+	m, ok := capabilityRegistry[integration]
+	if !ok {
+		return CapabilitySpec{}, false
+	}
+	spec, ok := m[name]
+	return spec, ok
+}
+
+func CapabilitiesFor(integration string) map[string]CapabilitySpec {
+	return capabilityRegistry[integration]
+}
+
+// expandCapabilities converts declared capabilities into explicit allow rules.
+func ExpandCapabilities(integration string, callers []CallerConfig) []CallerConfig {
+	for i := range callers {
+		for _, cap := range callers[i].Capabilities {
+			spec, ok := getCapability(integration, cap.Name)
+			if !ok {
+				continue
+			}
+			rules, err := spec.Generate(cap.Params)
+			if err != nil {
+				continue
+			}
+			callers[i].Rules = append(callers[i].Rules, rules...)
+		}
+		callers[i].Capabilities = nil
+	}
+	return callers
+}
+
+// ListCapabilities exposes capability names for CLI usage.
+func AllCapabilities() map[string]map[string]CapabilitySpec {
+	return capabilityRegistry
+}

--- a/app/integrationplugins/slack/capabilities.go
+++ b/app/integrationplugins/slack/capabilities.go
@@ -1,0 +1,36 @@
+package slack
+
+import "fmt"
+
+import integrationplugins "github.com/winhowes/AuthTransformer/app/integrationplugins"
+
+func init() {
+	integrationplugins.RegisterCapability("slack", "post_public_as", integrationplugins.CapabilitySpec{
+		Params: []string{"username"},
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			user, _ := p["username"].(string)
+			if user == "" {
+				return nil, fmt.Errorf("username required")
+			}
+			rule := integrationplugins.CallRule{Path: "/chat.postMessage", Methods: map[string]integrationplugins.RequestConstraint{"POST": {Body: map[string]interface{}{"username": user}}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("slack", "post_channels_as", integrationplugins.CapabilitySpec{
+		Params: []string{"username", "channels"},
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			user, _ := p["username"].(string)
+			ch, _ := p["channels"].([]interface{})
+			if user == "" || len(ch) == 0 {
+				return nil, fmt.Errorf("username and channels required")
+			}
+			allowed := make([]interface{}, len(ch))
+			for i, c := range ch {
+				allowed[i] = c
+			}
+			rule := integrationplugins.CallRule{Path: "/chat.postMessage", Methods: map[string]integrationplugins.RequestConstraint{"POST": {Body: map[string]interface{}{"username": user, "channel": allowed}}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+}

--- a/app/integrationplugins/types.go
+++ b/app/integrationplugins/types.go
@@ -1,0 +1,19 @@
+package integrationplugins
+
+// CallRule ties a path pattern to method-specific constraints.
+type CallRule struct {
+	Path    string                       `json:"path"`
+	Methods map[string]RequestConstraint `json:"methods"`
+}
+
+// RequestConstraint lists required headers and body parameters.
+type RequestConstraint struct {
+	Headers []string               `json:"headers"`
+	Body    map[string]interface{} `json:"body"`
+}
+
+type CallerConfig struct {
+	ID           string             `json:"id"`
+	Capabilities []CapabilityConfig `json:"capabilities,omitempty"`
+	Rules        []CallRule         `json:"rules"`
+}

--- a/app/main.go
+++ b/app/main.go
@@ -18,6 +18,8 @@ import (
 	_ "github.com/winhowes/AuthTransformer/app/authplugins/basic"
 	_ "github.com/winhowes/AuthTransformer/app/authplugins/google_oidc"
 	_ "github.com/winhowes/AuthTransformer/app/authplugins/token"
+	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/github"
+	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/slack"
 	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
 )
 

--- a/cmd/allowlist/main.go
+++ b/cmd/allowlist/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/winhowes/AuthTransformer/cmd/allowlist/plugins"
+)
+
+var file = flag.String("file", "allowlist.json", "allowlist file")
+
+func main() {
+	flag.Parse()
+	if flag.NArg() < 1 {
+		usage()
+	}
+	switch flag.Arg(0) {
+	case "list":
+		listCaps()
+	case "add":
+		addEntry(flag.Args()[1:])
+	default:
+		usage()
+	}
+}
+
+func usage() {
+	fmt.Println("usage: allowlist <list|add> [options]")
+	os.Exit(1)
+}
+
+func listCaps() {
+	for integ, caps := range plugins.List() {
+		fmt.Println(integ + ":")
+		for name, spec := range caps {
+			fmt.Printf("  %s (params: %s)\n", name, strings.Join(spec.Params, ","))
+		}
+	}
+}
+
+func addEntry(args []string) {
+	fs := flag.NewFlagSet("add", flag.ExitOnError)
+	integ := fs.String("integration", "", "integration name")
+	caller := fs.String("caller", "", "caller id")
+	capName := fs.String("capability", "", "capability name")
+	paramList := fs.String("params", "", "comma separated key=value")
+	fs.Parse(args)
+	if *integ == "" || *caller == "" || *capName == "" {
+		fmt.Println("-integration, -caller and -capability required")
+		return
+	}
+	params := map[string]interface{}{}
+	if *paramList != "" {
+		for _, kv := range strings.Split(*paramList, ",") {
+			parts := strings.SplitN(kv, "=", 2)
+			if len(parts) == 2 {
+				params[parts[0]] = parts[1]
+			}
+		}
+	}
+
+	// load file
+	data, err := ioutil.ReadFile(*file)
+	if err != nil && !os.IsNotExist(err) {
+		fmt.Println(err)
+		return
+	}
+	var entries []plugins.AllowlistEntry
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &entries); err != nil {
+			fmt.Println(err)
+			return
+		}
+	}
+	// find integration
+	var entry *plugins.AllowlistEntry
+	for i := range entries {
+		if entries[i].Integration == *integ {
+			entry = &entries[i]
+			break
+		}
+	}
+	if entry == nil {
+		entries = append(entries, plugins.AllowlistEntry{Integration: *integ})
+		entry = &entries[len(entries)-1]
+	}
+	// find caller
+	var callerCfg *plugins.CallerConfig
+	for i := range entry.Callers {
+		if entry.Callers[i].ID == *caller {
+			callerCfg = &entry.Callers[i]
+			break
+		}
+	}
+	if callerCfg == nil {
+		entry.Callers = append(entry.Callers, plugins.CallerConfig{ID: *caller})
+		callerCfg = &entry.Callers[len(entry.Callers)-1]
+	}
+	callerCfg.Capabilities = append(callerCfg.Capabilities, plugins.CapabilityConfig{Name: *capName, Params: params})
+
+	out, _ := json.MarshalIndent(entries, "", "    ")
+	ioutil.WriteFile(*file, out, 0644)
+}

--- a/cmd/allowlist/plugins/github.go
+++ b/cmd/allowlist/plugins/github.go
@@ -1,0 +1,7 @@
+package plugins
+
+func init() {
+	RegisterCapability("github", "comment", CapabilitySpec{
+		Params: []string{"repo"},
+	})
+}

--- a/cmd/allowlist/plugins/registry.go
+++ b/cmd/allowlist/plugins/registry.go
@@ -1,0 +1,19 @@
+package plugins
+
+// CapabilitySpec describes a capability's parameters.
+type CapabilitySpec struct {
+	Params []string
+}
+
+var registry = map[string]map[string]CapabilitySpec{}
+
+func RegisterCapability(integration, name string, spec CapabilitySpec) {
+	if registry[integration] == nil {
+		registry[integration] = map[string]CapabilitySpec{}
+	}
+	registry[integration][name] = spec
+}
+
+func List() map[string]map[string]CapabilitySpec {
+	return registry
+}

--- a/cmd/allowlist/plugins/slack.go
+++ b/cmd/allowlist/plugins/slack.go
@@ -1,0 +1,6 @@
+package plugins
+
+func init() {
+	RegisterCapability("slack", "post_public_as", CapabilitySpec{Params: []string{"username"}})
+	RegisterCapability("slack", "post_channels_as", CapabilitySpec{Params: []string{"username", "channels"}})
+}

--- a/cmd/allowlist/plugins/types.go
+++ b/cmd/allowlist/plugins/types.go
@@ -1,0 +1,28 @@
+package plugins
+
+// CallerConfig mirrors the server structure for CLI use.
+type CallerConfig struct {
+	ID           string             `json:"id"`
+	Capabilities []CapabilityConfig `json:"capabilities,omitempty"`
+	Rules        []CallRule         `json:"rules"`
+}
+
+type CapabilityConfig struct {
+	Name   string                 `json:"name"`
+	Params map[string]interface{} `json:"params"`
+}
+
+type CallRule struct {
+	Path    string                       `json:"path"`
+	Methods map[string]RequestConstraint `json:"methods"`
+}
+
+type RequestConstraint struct {
+	Headers []string               `json:"headers"`
+	Body    map[string]interface{} `json:"body"`
+}
+
+type AllowlistEntry struct {
+	Integration string         `json:"integration"`
+	Callers     []CallerConfig `json:"callers"`
+}


### PR DESCRIPTION
## Summary
- add capability registry with GitHub and Slack examples
- expand allowlist via capabilities
- introduce a new allowlist CLI
- reorganize plugin files

## Testing
- `go vet ./...`
- `go test ./...`
