### PR TITLE
Add config file flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ AuthTransformer is a simple Go-based reverse proxy that injects authentication t
 1. **Build or Run**
    
    ```bash
-   go run ./app
+   go run ./app -config app/config.json
    ```
    
    Or build an executable:
    
    ```bash
    go build -o authtransformer ./app
-   ./authtransformer
+   ./authtransformer -config app/config.json
    ```
 
 2. **Configuration File**
@@ -139,7 +139,7 @@ The CLI in `cmd/integrations` can be extended by creating a new helper in
 
 3. **Running**
 
-   The listen address can be configured with the `-addr` flag. By default the server listens on `:8080`. Incoming requests are matched against the `X-AT-Int` header, if present, or otherwise the host header to determine the route and associated authentication plugin. Use `-disable_x_at_int` to ignore the header entirely or `-x_at_int_host` to only respect the header when a specific host is requested. The allowlist file can be specified with `-allowlist`; it defaults to `allowlist.json`.
+   The listen address can be configured with the `-addr` flag. By default the server listens on `:8080`. Incoming requests are matched against the `X-AT-Int` header, if present, or otherwise the host header to determine the route and associated authentication plugin. Use `-disable_x_at_int` to ignore the header entirely or `-x_at_int_host` to only respect the header when a specific host is requested. The configuration file is chosen with `-config` (default `config.json`). The allowlist file can be specified with `-allowlist`; it defaults to `allowlist.json`.
 
 4. **Run Locally**
 
@@ -176,7 +176,7 @@ The CLI in `cmd/integrations` can be extended by creating a new helper in
    ```bash
    export IN_TOKEN=secret-in
    export OUT_TOKEN=secret-out
-   go run ./app -allowlist allowlist.json
+   go run ./app -config app/config.json -allowlist app/allowlist.json
    ```
 
    In another terminal, call the proxy using the integration name as the Host header:

--- a/app/main.go
+++ b/app/main.go
@@ -53,6 +53,7 @@ var disableXATInt = flag.Bool("disable_x_at_int", false, "ignore X-AT-Int header
 var xAtIntHost = flag.String("x_at_int_host", "", "only respect X-AT-Int header when request Host matches this value")
 var addr = flag.String("addr", ":8080", "listen address")
 var allowlistFile = flag.String("allowlist", "allowlist.json", "path to allowlist configuration")
+var configFile = flag.String("config", "config.json", "path to configuration file")
 
 func loadConfig(filename string) (*Config, error) {
 	f, err := os.Open(filename)
@@ -223,7 +224,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	flag.Parse()
 
-	config, err := loadConfig("config.json")
+	config, err := loadConfig(*configFile)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -22,3 +22,21 @@ func TestAddrFlagSet(t *testing.T) {
 		t.Fatalf("expected addr 127.0.0.1:9000, got %s", *addr)
 	}
 }
+
+func TestConfigFlagDefault(t *testing.T) {
+	if *configFile != "config.json" {
+		t.Fatalf("expected default config.json, got %s", *configFile)
+	}
+}
+
+func TestConfigFlagSet(t *testing.T) {
+	old := *configFile
+	t.Cleanup(func() { flag.Set("config", old) })
+
+	if err := flag.Set("config", "custom.json"); err != nil {
+		t.Fatal(err)
+	}
+	if *configFile != "custom.json" {
+		t.Fatalf("expected config custom.json, got %s", *configFile)
+	}
+}


### PR DESCRIPTION
## Summary
- add `-config` flag to choose the configuration file
- read config from the path provided by `-config`
- document the new flag in usage instructions
- update local run command in README
- test flag defaults and flag setting

## Testing
- `go vet ./...`
- `go test ./...`
