### PR TITLE
Prevent duplicate integrations

### DIFF
--- a/app/integration.go
+++ b/app/integration.go
@@ -211,10 +211,13 @@ func AddIntegration(i *Integration) error {
 	}
 
 	// ─── Rate limiters & storage ──────────────────────────────────────────────
+	integrations.Lock()
+	if _, exists := integrations.m[i.Name]; exists {
+		integrations.Unlock()
+		return fmt.Errorf("integration %s already exists", i.Name)
+	}
 	i.inLimiter = NewRateLimiter(i.InRateLimit, time.Minute)
 	i.outLimiter = NewRateLimiter(i.OutRateLimit, time.Minute)
-
-	integrations.Lock()
 	integrations.m[i.Name] = i
 	integrations.Unlock()
 

--- a/app/integration_test.go
+++ b/app/integration_test.go
@@ -80,3 +80,22 @@ func TestAddIntegrationInvalidDestination(t *testing.T) {
 		t.Fatal("expected error for invalid destination")
 	}
 }
+
+func TestAddIntegrationDuplicateName(t *testing.T) {
+	i := &Integration{
+		Name:         "testduplicate",
+		Destination:  "http://example.com",
+		InRateLimit:  1,
+		OutRateLimit: 1,
+	}
+	if err := AddIntegration(i); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Cleanup(func() {
+		i.inLimiter.Stop()
+		i.outLimiter.Stop()
+	})
+	if err := AddIntegration(i); err == nil {
+		t.Fatal("expected error for duplicate name")
+	}
+}


### PR DESCRIPTION
## Summary
- reject duplicate integration names in `AddIntegration`
- cover duplicate integration scenario in tests

## Testing
- `go test ./...`
