### PR TITLE
Add HMAC signature auth plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The project exists to make it trivial to translate one type of authentication in
 ## Features
 
 - **Reverse Proxy**: Forwards incoming HTTP requests to a target backend based on the requested host or `X-AT-Int` header. The header can be disabled or restricted to a specific host using command-line flags.
-- **Pluggable Authentication**: Supports "basic", "token" and Google OIDC authentication types with room for extension.
+- **Pluggable Authentication**: Supports "basic", "token", `hmac_signature` and Google OIDC authentication types with room for extension.
 - **Extensible Plugins**: Add new auth, secret and integration plugins to cover different systems.
 - **Rate Limiting**: Limits the number of requests per caller and per host within a rolling window.
 - **Allowlist**: Integrations can restrict specific callers to particular paths, methods and required parameters.
@@ -119,6 +119,7 @@ fields and may list required values:
    - **integrations**: Defines proxy routes, rate limits and authentication methods. Secret references use the `env:` or KMS-prefixed formats described below.
    - **google_oidc**: Outgoing auth plugin that retrieves an ID token from the GCP metadata server and sets it in the `Authorization` header for backend requests. The incoming variant validates Google ID tokens against a configured audience.
    - **basic**: Performs HTTP Basic authentication using credentials loaded from configured secrets.
+   - **hmac_signature**: Computes or verifies request HMAC digests with a configurable algorithm.
 
 ### Capabilities
 

--- a/app/authplugins/hmac/hmac_test.go
+++ b/app/authplugins/hmac/hmac_test.go
@@ -1,0 +1,75 @@
+package hmacsig
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
+)
+
+func TestHMACOutgoingAddAuth(t *testing.T) {
+	r := &http.Request{Header: http.Header{}, Body: io.NopCloser(strings.NewReader("hello"))}
+	p := HMACSignature{}
+	t.Setenv("SECRET", "key")
+	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:SECRET"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.AddAuth(r, cfg)
+	mac := hmac.New(sha256.New, []byte("key"))
+	mac.Write([]byte("hello"))
+	expected := hex.EncodeToString(mac.Sum(nil))
+	if got := r.Header.Get("X-Signature"); got != expected {
+		t.Fatalf("expected %s, got %s", expected, got)
+	}
+}
+
+func TestHMACIncomingAuth(t *testing.T) {
+	body := "hello"
+	mac := hmac.New(sha256.New, []byte("key"))
+	mac.Write([]byte(body))
+	sig := hex.EncodeToString(mac.Sum(nil))
+	r := &http.Request{Header: http.Header{"X-Signature": []string{sig}}, Body: io.NopCloser(strings.NewReader(body))}
+	p := HMACSignatureAuth{}
+	t.Setenv("SECRET", "key")
+	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:SECRET"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.Authenticate(r, cfg) {
+		t.Fatal("expected authentication to succeed")
+	}
+}
+
+func TestHMACIncomingAuthFail(t *testing.T) {
+	body := "hello"
+	mac := hmac.New(sha256.New, []byte("bad"))
+	mac.Write([]byte(body))
+	sig := hex.EncodeToString(mac.Sum(nil))
+	r := &http.Request{Header: http.Header{"X-Signature": []string{sig}}, Body: io.NopCloser(strings.NewReader(body))}
+	p := HMACSignatureAuth{}
+	t.Setenv("SECRET", "key")
+	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:SECRET"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Authenticate(r, cfg) {
+		t.Fatal("expected authentication to fail")
+	}
+}
+
+func TestHMACPluginOptionalParams(t *testing.T) {
+	in := HMACSignatureAuth{}
+	out := HMACSignature{}
+	if got := in.OptionalParams(); len(got) != 3 || got[0] != "header" {
+		t.Fatalf("unexpected optional params: %v", got)
+	}
+	if got := out.OptionalParams(); len(got) != 3 || got[0] != "header" {
+		t.Fatalf("unexpected optional params: %v", got)
+	}
+}

--- a/app/authplugins/hmac/incoming.go
+++ b/app/authplugins/hmac/incoming.go
@@ -1,0 +1,100 @@
+package hmacsig
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"net/http"
+
+	"github.com/winhowes/AuthTransformer/app/authplugins"
+	"github.com/winhowes/AuthTransformer/app/secrets"
+)
+
+// inParams configures validation of generic HMAC signatures.
+// Algo may be one of sha1, sha256 or sha512.
+type inParams struct {
+	Secrets []string `json:"secrets"`
+	Header  string   `json:"header"`
+	Prefix  string   `json:"prefix"`
+	Algo    string   `json:"algo"`
+}
+
+type HMACSignatureAuth struct{}
+
+func (h *HMACSignatureAuth) Name() string             { return "hmac_signature" }
+func (h *HMACSignatureAuth) RequiredParams() []string { return []string{"secrets"} }
+func (h *HMACSignatureAuth) OptionalParams() []string { return []string{"header", "prefix", "algo"} }
+
+func hashFunc(algo string) (func() hash.Hash, error) {
+	switch algo {
+	case "sha1":
+		return sha1.New, nil
+	case "sha256", "":
+		return sha256.New, nil
+	case "sha512":
+		return sha512.New, nil
+	default:
+		return nil, fmt.Errorf("unsupported algo %s", algo)
+	}
+}
+
+func (h *HMACSignatureAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
+	p, err := authplugins.ParseParams[inParams](m)
+	if err != nil {
+		return nil, err
+	}
+	if len(p.Secrets) == 0 {
+		return nil, fmt.Errorf("missing secrets")
+	}
+	if p.Header == "" {
+		p.Header = "X-Signature"
+	}
+	if p.Algo == "" {
+		p.Algo = "sha256"
+	}
+	if _, err := hashFunc(p.Algo); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func (h *HMACSignatureAuth) Authenticate(r *http.Request, params interface{}) bool {
+	cfg, ok := params.(*inParams)
+	if !ok {
+		return false
+	}
+	newHash, err := hashFunc(cfg.Algo)
+	if err != nil {
+		return false
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return false
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	sig := r.Header.Get(cfg.Header)
+	if sig == "" {
+		return false
+	}
+	for _, ref := range cfg.Secrets {
+		secret, err := secrets.LoadSecret(ref)
+		if err != nil {
+			continue
+		}
+		mac := hmac.New(newHash, []byte(secret))
+		mac.Write(body)
+		expected := cfg.Prefix + hex.EncodeToString(mac.Sum(nil))
+		if hmac.Equal([]byte(expected), []byte(sig)) {
+			return true
+		}
+	}
+	return false
+}
+
+func init() { authplugins.RegisterIncoming(&HMACSignatureAuth{}) }

--- a/app/authplugins/hmac/outgoing.go
+++ b/app/authplugins/hmac/outgoing.go
@@ -1,0 +1,91 @@
+package hmacsig
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"net/http"
+
+	"github.com/winhowes/AuthTransformer/app/authplugins"
+	"github.com/winhowes/AuthTransformer/app/secrets"
+)
+
+// outParams configures HMAC signing of outgoing requests.
+// Algo may be one of sha1, sha256 or sha512.
+type outParams struct {
+	Secrets []string `json:"secrets"`
+	Header  string   `json:"header"`
+	Prefix  string   `json:"prefix"`
+	Algo    string   `json:"algo"`
+}
+
+type HMACSignature struct{}
+
+func (h *HMACSignature) Name() string             { return "hmac_signature" }
+func (h *HMACSignature) RequiredParams() []string { return []string{"secrets"} }
+func (h *HMACSignature) OptionalParams() []string { return []string{"header", "prefix", "algo"} }
+
+func hashFuncOut(algo string) (func() hash.Hash, error) {
+	switch algo {
+	case "sha1":
+		return sha1.New, nil
+	case "sha256", "":
+		return sha256.New, nil
+	case "sha512":
+		return sha512.New, nil
+	default:
+		return nil, fmt.Errorf("unsupported algo %s", algo)
+	}
+}
+
+func (h *HMACSignature) ParseParams(m map[string]interface{}) (interface{}, error) {
+	p, err := authplugins.ParseParams[outParams](m)
+	if err != nil {
+		return nil, err
+	}
+	if len(p.Secrets) == 0 {
+		return nil, fmt.Errorf("missing secrets")
+	}
+	if p.Header == "" {
+		p.Header = "X-Signature"
+	}
+	if p.Algo == "" {
+		p.Algo = "sha256"
+	}
+	if _, err := hashFuncOut(p.Algo); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func (h *HMACSignature) AddAuth(r *http.Request, params interface{}) {
+	cfg, ok := params.(*outParams)
+	if !ok || len(cfg.Secrets) == 0 {
+		return
+	}
+	newHash, err := hashFuncOut(cfg.Algo)
+	if err != nil {
+		return
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	secret, err := secrets.LoadRandomSecret(cfg.Secrets)
+	if err != nil {
+		return
+	}
+	mac := hmac.New(newHash, []byte(secret))
+	mac.Write(body)
+	sig := cfg.Prefix + hex.EncodeToString(mac.Sum(nil))
+	r.Header.Set(cfg.Header, sig)
+}
+
+func init() { authplugins.RegisterOutgoing(&HMACSignature{}) }


### PR DESCRIPTION
## Summary
- introduce a generic `hmac_signature` auth plugin for incoming and outgoing requests
- document the new plugin in README
- add tests for HMAC auth

## Testing
- `go test ./...`
