### PR TITLE
Add generic JWT and mTLS auth plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The project exists to make it trivial to translate one type of authentication in
 ## Features
 
 - **Reverse Proxy**: Forwards incoming HTTP requests to a target backend based on the requested host or `X-AT-Int` header. The header can be disabled or restricted to a specific host using command-line flags.
-- **Pluggable Authentication**: Supports "basic", "token" and Google OIDC authentication types with room for extension.
+- **Pluggable Authentication**: Supports "basic", "token", "jwt" and "mtls" authentication types including Google OIDC with room for extension.
 - **Rate Limiting**: Limits the number of requests per caller and per host within a rolling window.
 - **Allowlist**: Integrations can restrict specific callers to particular paths, methods and required parameters.
 - **Configuration Driven**: Behavior is controlled via a JSON configuration file.
@@ -117,6 +117,9 @@ fields and may list required values:
 
    - **integrations**: Defines proxy routes, rate limits and authentication methods. Secret references use the `env:` or KMS-prefixed formats described below.
    - **google_oidc**: Outgoing auth plugin that retrieves an ID token from the GCP metadata server and sets it in the `Authorization` header for backend requests. The incoming variant validates Google ID tokens against a configured audience.
+   - **jwt**: Validates generic JWTs using provided keys.
+   - **mtls**: Requires a verified client certificate and optional subject match.
+   - **token**: Header token comparison for simple shared secrets.
    - **basic**: Performs HTTP Basic authentication using credentials loaded from configured secrets.
 
 ### Capabilities

--- a/app/authplugins/jwt/incoming.go
+++ b/app/authplugins/jwt/incoming.go
@@ -1,0 +1,199 @@
+package jwt
+
+import (
+	"crypto"
+	"crypto/hmac"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/winhowes/AuthTransformer/app/authplugins"
+	"github.com/winhowes/AuthTransformer/app/secrets"
+)
+
+// inParams configures JWT validation.
+type inParams struct {
+	Secrets  []string `json:"secrets"`
+	Audience string   `json:"audience"`
+	Issuer   string   `json:"issuer"`
+	Header   string   `json:"header"`
+	Prefix   string   `json:"prefix"`
+}
+
+type JWTAuth struct{}
+
+func (j *JWTAuth) Name() string             { return "jwt" }
+func (j *JWTAuth) RequiredParams() []string { return []string{"secrets"} }
+func (j *JWTAuth) OptionalParams() []string {
+	return []string{"audience", "issuer", "header", "prefix"}
+}
+
+func (j *JWTAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
+	p, err := authplugins.ParseParams[inParams](m)
+	if err != nil {
+		return nil, err
+	}
+	if len(p.Secrets) == 0 {
+		return nil, fmt.Errorf("missing secrets")
+	}
+	if p.Header == "" {
+		p.Header = "Authorization"
+	}
+	if p.Prefix == "" {
+		p.Prefix = "Bearer "
+	}
+	return p, nil
+}
+
+func parseHeaderPayload(tok string) (header map[string]interface{}, payload map[string]interface{}, parts []string, ok bool) {
+	parts = strings.Split(tok, ".")
+	if len(parts) != 3 {
+		return nil, nil, nil, false
+	}
+	hBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, nil, nil, false
+	}
+	if err := json.Unmarshal(hBytes, &header); err != nil {
+		return nil, nil, nil, false
+	}
+	pBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, nil, nil, false
+	}
+	if err := json.Unmarshal(pBytes, &payload); err != nil {
+		return nil, nil, nil, false
+	}
+	return header, payload, parts, true
+}
+
+func verifyHS256(parts []string, key []byte) bool {
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(parts[0] + "." + parts[1]))
+	sig := h.Sum(nil)
+	expected := base64.RawURLEncoding.EncodeToString(sig)
+	return hmac.Equal([]byte(expected), []byte(parts[2]))
+}
+
+func verifyRS256(parts []string, pemData []byte) bool {
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return false
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return false
+	}
+	rsaPub, ok := pub.(*rsa.PublicKey)
+	if !ok {
+		return false
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return false
+	}
+	hash := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	return rsa.VerifyPKCS1v15(rsaPub, crypto.SHA256, hash[:], sig) == nil
+}
+
+func matchAudience(claim interface{}, want string) bool {
+	switch v := claim.(type) {
+	case string:
+		return v == want
+	case []interface{}:
+		for _, elem := range v {
+			if s, ok := elem.(string); ok && s == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (j *JWTAuth) Authenticate(r *http.Request, p interface{}) bool {
+	cfg, ok := p.(*inParams)
+	if !ok {
+		return false
+	}
+	headerVal := r.Header.Get(cfg.Header)
+	if !strings.HasPrefix(headerVal, cfg.Prefix) {
+		return false
+	}
+	token := strings.TrimPrefix(headerVal, cfg.Prefix)
+	header, claims, parts, ok := parseHeaderPayload(token)
+	if !ok {
+		return false
+	}
+	alg, _ := header["alg"].(string)
+	verified := false
+	for _, ref := range cfg.Secrets {
+		key, err := secrets.LoadSecret(ref)
+		if err != nil {
+			continue
+		}
+		switch alg {
+		case "HS256":
+			if verifyHS256(parts, []byte(key)) {
+				verified = true
+			}
+		case "RS256":
+			if verifyRS256(parts, []byte(key)) {
+				verified = true
+			}
+		default:
+			return false
+		}
+		if verified {
+			break
+		}
+	}
+	if !verified {
+		return false
+	}
+	if aud := cfg.Audience; aud != "" {
+		if claim, ok := claims["aud"]; !ok || !matchAudience(claim, aud) {
+			return false
+		}
+	}
+	if iss := cfg.Issuer; iss != "" {
+		if claim, ok := claims["iss"].(string); !ok || claim != iss {
+			return false
+		}
+	}
+	if exp, ok := claims["exp"].(float64); ok {
+		if int64(exp) < time.Now().Unix() {
+			return false
+		}
+	}
+	return true
+}
+
+func (j *JWTAuth) Identify(r *http.Request, p interface{}) (string, bool) {
+	cfg, ok := p.(*inParams)
+	if !ok {
+		return "", false
+	}
+	headerVal := r.Header.Get(cfg.Header)
+	if !strings.HasPrefix(headerVal, cfg.Prefix) {
+		return "", false
+	}
+	token := strings.TrimPrefix(headerVal, cfg.Prefix)
+	_, claims, _, ok := parseHeaderPayload(token)
+	if !ok {
+		return "", false
+	}
+	sub, ok := claims["sub"].(string)
+	if !ok || sub == "" {
+		return "", false
+	}
+	return sub, true
+}
+
+func init() { authplugins.RegisterIncoming(&JWTAuth{}) }

--- a/app/authplugins/jwt/jwt_test.go
+++ b/app/authplugins/jwt/jwt_test.go
@@ -1,0 +1,59 @@
+package jwt
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
+)
+
+func makeHS256Token(aud, sub, key string, exp int64) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256"}`))
+	payloadMap := map[string]interface{}{"aud": aud, "sub": sub, "exp": exp}
+	payloadBytes, _ := json.Marshal(payloadMap)
+	body := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	signingInput := header + "." + body
+	h := hmac.New(sha256.New, []byte(key))
+	h.Write([]byte(signingInput))
+	sig := base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+	return signingInput + "." + sig
+}
+
+func TestJWTAuth(t *testing.T) {
+	key := "secret"
+	tok := makeHS256Token("aud1", "user1", key, time.Now().Add(time.Hour).Unix())
+	r := &http.Request{Header: http.Header{"Authorization": []string{"Bearer " + tok}}}
+	p := JWTAuth{}
+	t.Setenv("KEY", key)
+	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:KEY"}, "audience": "aud1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.Authenticate(r, cfg) {
+		t.Fatal("expected authentication to succeed")
+	}
+	id, ok := p.Identify(r, cfg)
+	if !ok || id != "user1" {
+		t.Fatalf("unexpected identifier %s", id)
+	}
+}
+
+func TestJWTAuthFail(t *testing.T) {
+	key := "secret"
+	tok := makeHS256Token("aud1", "user1", key, time.Now().Add(-time.Hour).Unix())
+	r := &http.Request{Header: http.Header{"Authorization": []string{"Bearer " + tok}}}
+	p := JWTAuth{}
+	t.Setenv("KEY", key)
+	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:KEY"}, "audience": "aud1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Authenticate(r, cfg) {
+		t.Fatal("expected authentication to fail")
+	}
+}

--- a/app/authplugins/mtls/incoming.go
+++ b/app/authplugins/mtls/incoming.go
@@ -1,0 +1,54 @@
+package mtls
+
+import (
+	"net/http"
+
+	"github.com/winhowes/AuthTransformer/app/authplugins"
+)
+
+// mtlsParams defines allowed subject names for client certificates.
+type mtlsParams struct {
+	Subjects []string `json:"subjects"`
+}
+
+type MTLSAuth struct{}
+
+func (m *MTLSAuth) Name() string             { return "mtls" }
+func (m *MTLSAuth) RequiredParams() []string { return []string{} }
+func (m *MTLSAuth) OptionalParams() []string { return []string{"subjects"} }
+
+func (m *MTLSAuth) ParseParams(data map[string]interface{}) (interface{}, error) {
+	return authplugins.ParseParams[mtlsParams](data)
+}
+
+func (m *MTLSAuth) Authenticate(r *http.Request, p interface{}) bool {
+	cfg, ok := p.(*mtlsParams)
+	if !ok {
+		return false
+	}
+	if r.TLS == nil || len(r.TLS.VerifiedChains) == 0 {
+		return false
+	}
+	if len(cfg.Subjects) == 0 {
+		return true
+	}
+	if len(r.TLS.PeerCertificates) == 0 {
+		return false
+	}
+	subj := r.TLS.PeerCertificates[0].Subject.CommonName
+	for _, s := range cfg.Subjects {
+		if subj == s {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MTLSAuth) Identify(r *http.Request, p interface{}) (string, bool) {
+	if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+		return "", false
+	}
+	return r.TLS.PeerCertificates[0].Subject.CommonName, true
+}
+
+func init() { authplugins.RegisterIncoming(&MTLSAuth{}) }

--- a/app/authplugins/mtls/mtls_test.go
+++ b/app/authplugins/mtls/mtls_test.go
@@ -1,0 +1,40 @@
+package mtls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net/http"
+	"testing"
+
+	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
+)
+
+func TestMTLSAuth(t *testing.T) {
+	cert := &x509.Certificate{Subject: pkix.Name{CommonName: "client"}}
+	r := &http.Request{TLS: &tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{cert}}, PeerCertificates: []*x509.Certificate{cert}}}
+	p := MTLSAuth{}
+	cfg, err := p.ParseParams(map[string]interface{}{"subjects": []string{"client"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.Authenticate(r, cfg) {
+		t.Fatal("expected authentication to succeed")
+	}
+	id, ok := p.Identify(r, cfg)
+	if !ok || id != "client" {
+		t.Fatalf("unexpected id %s", id)
+	}
+}
+
+func TestMTLSAuthFail(t *testing.T) {
+	r := &http.Request{}
+	p := MTLSAuth{}
+	cfg, err := p.ParseParams(map[string]interface{}{"subjects": []string{"client"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Authenticate(r, cfg) {
+		t.Fatal("expected failure without TLS")
+	}
+}


### PR DESCRIPTION
## Summary
- implement `jwt` incoming auth plugin for verifying JWTs with provided keys
- implement `mtls` incoming auth plugin for requiring verified client certs
- document new plugins in README
- include unit tests

## Testing
- `go test ./...`
