### PR TITLE
Add Asana, Zendesk and ServiceNow support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ Integration plugins can bundle common allowlist rules into **capabilities**. Ass
 - `slack.post_public_as` – permit posting a message as a specific username.
 - `slack.post_channels_as` – restrict posting to a defined set of channels.
 - `github.comment` – allow creating issue comments in a given repository (requires the `repo` parameter).
+- `asana.create_task`, `linear.create_task`, `jira.create_task` – permit creating tasks or issues.
+- `asana.update_status`, `linear.update_status`, `jira.update_status` – allow modifying task or issue status.
+- `asana.add_comment`, `linear.add_comment`, `jira.add_comment` – permit adding comments.
+- `zendesk.open_ticket`, `servicenow.open_ticket` – allow creating support tickets.
+- `zendesk.update_ticket`, `servicenow.update_ticket` – permit updating ticket details.
+- `zendesk.query_status`, `servicenow.query_status` – allow reading ticket status.
 
 ### Secret Plugin Environment Variables
 
@@ -212,7 +218,7 @@ go run ./app -debug
 Then run the CLI to POST a new integration configuration. The `-server` flag
 controls where the CLI sends the request (default `http://localhost:8080/integrations`).
 
-A helper CLI is available under `cmd/integrations` to create Slack, GitHub, Jira or Linear integrations with minimal flags.
+A helper CLI is available under `cmd/integrations` to create Slack, GitHub, Jira, Linear, Asana, Zendesk or ServiceNow integrations with minimal flags.
 
 Add Slack:
 ```bash
@@ -232,6 +238,18 @@ go run ./cmd/integrations jira -token env:JIRA_TOKEN
 Add Linear:
 ```bash
 go run ./cmd/integrations linear -token env:LINEAR_TOKEN
+```
+Add Asana:
+```bash
+go run ./cmd/integrations asana -token env:ASANA_TOKEN
+```
+Add Zendesk:
+```bash
+go run ./cmd/integrations zendesk -token env:ZENDESK_TOKEN
+```
+Add ServiceNow:
+```bash
+go run ./cmd/integrations servicenow -token env:SERVICENOW_TOKEN
 ```
 
 ## Allowlist CLI

--- a/app/integrationplugins/asana/capabilities.go
+++ b/app/integrationplugins/asana/capabilities.go
@@ -1,0 +1,26 @@
+package asana
+
+import integrationplugins "github.com/winhowes/AuthTransformer/app/integrationplugins"
+
+func init() {
+	integrationplugins.RegisterCapability("asana", "create_task", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/tasks", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("asana", "update_status", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/tasks/*", Methods: map[string]integrationplugins.RequestConstraint{"PUT": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("asana", "add_comment", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/tasks/*/stories", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+}

--- a/app/integrationplugins/jira/capabilities.go
+++ b/app/integrationplugins/jira/capabilities.go
@@ -1,0 +1,26 @@
+package jira
+
+import integrationplugins "github.com/winhowes/AuthTransformer/app/integrationplugins"
+
+func init() {
+	integrationplugins.RegisterCapability("jira", "create_task", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/rest/api/**/issue", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("jira", "update_status", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/rest/api/**/issue/*", Methods: map[string]integrationplugins.RequestConstraint{"PUT": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("jira", "add_comment", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/rest/api/**/issue/*/comment", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+}

--- a/app/integrationplugins/linear/capabilities.go
+++ b/app/integrationplugins/linear/capabilities.go
@@ -1,0 +1,26 @@
+package linear
+
+import integrationplugins "github.com/winhowes/AuthTransformer/app/integrationplugins"
+
+func init() {
+	integrationplugins.RegisterCapability("linear", "create_task", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/issues", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("linear", "update_status", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/issues/*", Methods: map[string]integrationplugins.RequestConstraint{"PATCH": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("linear", "add_comment", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/issues/*/comments", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+}

--- a/app/integrationplugins/servicenow/capabilities.go
+++ b/app/integrationplugins/servicenow/capabilities.go
@@ -1,0 +1,26 @@
+package servicenow
+
+import integrationplugins "github.com/winhowes/AuthTransformer/app/integrationplugins"
+
+func init() {
+	integrationplugins.RegisterCapability("servicenow", "open_ticket", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/api/**/now/table/incident", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("servicenow", "update_ticket", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/api/**/now/table/incident/*", Methods: map[string]integrationplugins.RequestConstraint{"PATCH": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("servicenow", "query_status", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/api/**/now/table/incident/*", Methods: map[string]integrationplugins.RequestConstraint{"GET": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+}

--- a/app/integrationplugins/zendesk/capabilities.go
+++ b/app/integrationplugins/zendesk/capabilities.go
@@ -1,0 +1,26 @@
+package zendesk
+
+import integrationplugins "github.com/winhowes/AuthTransformer/app/integrationplugins"
+
+func init() {
+	integrationplugins.RegisterCapability("zendesk", "open_ticket", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/api/v2/tickets", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("zendesk", "update_ticket", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/api/v2/tickets/*", Methods: map[string]integrationplugins.RequestConstraint{"PUT": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("zendesk", "query_status", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/api/v2/tickets/*", Methods: map[string]integrationplugins.RequestConstraint{"GET": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+}

--- a/app/main.go
+++ b/app/main.go
@@ -18,8 +18,13 @@ import (
 	_ "github.com/winhowes/AuthTransformer/app/authplugins/basic"
 	_ "github.com/winhowes/AuthTransformer/app/authplugins/google_oidc"
 	_ "github.com/winhowes/AuthTransformer/app/authplugins/token"
+	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/asana"
 	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/github"
+	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/jira"
+	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/linear"
+	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/servicenow"
 	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/slack"
+	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/zendesk"
 	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
 )
 

--- a/cmd/allowlist/plugins/asana.go
+++ b/cmd/allowlist/plugins/asana.go
@@ -1,0 +1,7 @@
+package plugins
+
+func init() {
+	RegisterCapability("asana", "create_task", CapabilitySpec{})
+	RegisterCapability("asana", "update_status", CapabilitySpec{})
+	RegisterCapability("asana", "add_comment", CapabilitySpec{})
+}

--- a/cmd/allowlist/plugins/jira.go
+++ b/cmd/allowlist/plugins/jira.go
@@ -1,0 +1,7 @@
+package plugins
+
+func init() {
+	RegisterCapability("jira", "create_task", CapabilitySpec{})
+	RegisterCapability("jira", "update_status", CapabilitySpec{})
+	RegisterCapability("jira", "add_comment", CapabilitySpec{})
+}

--- a/cmd/allowlist/plugins/linear.go
+++ b/cmd/allowlist/plugins/linear.go
@@ -1,0 +1,7 @@
+package plugins
+
+func init() {
+	RegisterCapability("linear", "create_task", CapabilitySpec{})
+	RegisterCapability("linear", "update_status", CapabilitySpec{})
+	RegisterCapability("linear", "add_comment", CapabilitySpec{})
+}

--- a/cmd/allowlist/plugins/servicenow.go
+++ b/cmd/allowlist/plugins/servicenow.go
@@ -1,0 +1,7 @@
+package plugins
+
+func init() {
+	RegisterCapability("servicenow", "open_ticket", CapabilitySpec{})
+	RegisterCapability("servicenow", "update_ticket", CapabilitySpec{})
+	RegisterCapability("servicenow", "query_status", CapabilitySpec{})
+}

--- a/cmd/allowlist/plugins/zendesk.go
+++ b/cmd/allowlist/plugins/zendesk.go
@@ -1,0 +1,7 @@
+package plugins
+
+func init() {
+	RegisterCapability("zendesk", "open_ticket", CapabilitySpec{})
+	RegisterCapability("zendesk", "update_ticket", CapabilitySpec{})
+	RegisterCapability("zendesk", "query_status", CapabilitySpec{})
+}

--- a/cmd/integrations/main.go
+++ b/cmd/integrations/main.go
@@ -70,6 +70,39 @@ func main() {
 		}
 		integ := plugins.Linear(*name, *token)
 		sendIntegration(integ)
+	case "asana":
+		fs := flag.NewFlagSet("asana", flag.ExitOnError)
+		name := fs.String("name", "asana", "integration name")
+		token := fs.String("token", "", "secret reference for API token")
+		fs.Parse(args)
+		if *token == "" {
+			fmt.Fprintln(os.Stderr, "-token is required")
+			os.Exit(1)
+		}
+		integ := plugins.Asana(*name, *token)
+		sendIntegration(integ)
+	case "zendesk":
+		fs := flag.NewFlagSet("zendesk", flag.ExitOnError)
+		name := fs.String("name", "zendesk", "integration name")
+		token := fs.String("token", "", "secret reference for API token")
+		fs.Parse(args)
+		if *token == "" {
+			fmt.Fprintln(os.Stderr, "-token is required")
+			os.Exit(1)
+		}
+		integ := plugins.Zendesk(*name, *token)
+		sendIntegration(integ)
+	case "servicenow":
+		fs := flag.NewFlagSet("servicenow", flag.ExitOnError)
+		name := fs.String("name", "servicenow", "integration name")
+		token := fs.String("token", "", "secret reference for API token")
+		fs.Parse(args)
+		if *token == "" {
+			fmt.Fprintln(os.Stderr, "-token is required")
+			os.Exit(1)
+		}
+		integ := plugins.ServiceNow(*name, *token)
+		sendIntegration(integ)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown plugin %s\n", plugin)
 		os.Exit(1)

--- a/cmd/integrations/plugins/asana.go
+++ b/cmd/integrations/plugins/asana.go
@@ -1,0 +1,19 @@
+package plugins
+
+// Asana returns an Integration configured for the Asana API.
+func Asana(name, tokenRef string) Integration {
+	return Integration{
+		Name:         name,
+		Destination:  "https://app.asana.com/api/1.0",
+		InRateLimit:  100,
+		OutRateLimit: 100,
+		OutgoingAuth: []AuthPluginConfig{{
+			Type: "token",
+			Params: map[string]interface{}{
+				"secrets": []string{tokenRef},
+				"header":  "Authorization",
+				"prefix":  "Bearer ",
+			},
+		}},
+	}
+}

--- a/cmd/integrations/plugins/servicenow.go
+++ b/cmd/integrations/plugins/servicenow.go
@@ -1,0 +1,19 @@
+package plugins
+
+// ServiceNow returns an Integration configured for the ServiceNow API.
+func ServiceNow(name, tokenRef string) Integration {
+	return Integration{
+		Name:         name,
+		Destination:  "https://api.servicenow.com",
+		InRateLimit:  100,
+		OutRateLimit: 100,
+		OutgoingAuth: []AuthPluginConfig{{
+			Type: "token",
+			Params: map[string]interface{}{
+				"secrets": []string{tokenRef},
+				"header":  "Authorization",
+				"prefix":  "Bearer ",
+			},
+		}},
+	}
+}

--- a/cmd/integrations/plugins/zendesk.go
+++ b/cmd/integrations/plugins/zendesk.go
@@ -1,0 +1,19 @@
+package plugins
+
+// Zendesk returns an Integration configured for the Zendesk API.
+func Zendesk(name, tokenRef string) Integration {
+	return Integration{
+		Name:         name,
+		Destination:  "https://api.zendesk.com",
+		InRateLimit:  100,
+		OutRateLimit: 100,
+		OutgoingAuth: []AuthPluginConfig{{
+			Type: "token",
+			Params: map[string]interface{}{
+				"secrets": []string{tokenRef},
+				"header":  "Authorization",
+				"prefix":  "Bearer ",
+			},
+		}},
+	}
+}


### PR DESCRIPTION
## Summary
- add Asana, Linear, Jira, Zendesk and ServiceNow capabilities
- register new integration plugins in server and CLI helpers
- extend integration CLI to create Asana, Zendesk and ServiceNow integrations
- document new capabilities and CLI usage

## Testing
- `go vet ./...`
- `go test ./...`