### PR TITLE
Return error when env secret missing

### DIFF
--- a/app/secrets/plugins/env/plugin.go
+++ b/app/secrets/plugins/env/plugin.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/winhowes/AuthTransformer/app/secrets"
@@ -11,6 +12,12 @@ type envPlugin struct{}
 
 func (envPlugin) Prefix() string { return "env" }
 
-func (envPlugin) Load(id string) (string, error) { return os.Getenv(id), nil }
+func (envPlugin) Load(id string) (string, error) {
+	val, ok := os.LookupEnv(id)
+	if !ok {
+		return "", fmt.Errorf("%s not set", id)
+	}
+	return val, nil
+}
 
 func init() { secrets.Register(envPlugin{}) }

--- a/app/secrets/secret_test.go
+++ b/app/secrets/secret_test.go
@@ -22,6 +22,12 @@ func TestLoadSecretEnv(t *testing.T) {
 	}
 }
 
+func TestLoadSecretEnvMissing(t *testing.T) {
+	if _, err := secrets.LoadSecret("env:UNSET_VAR"); err == nil {
+		t.Fatal("expected error when variable is missing")
+	}
+}
+
 func TestLoadSecretUnknown(t *testing.T) {
 	if _, err := secrets.LoadSecret("unknown:id"); err == nil {
 		t.Fatal("expected error for unknown secret source")


### PR DESCRIPTION
## Summary
- validate environment variable exists in `env` secret plugin
- test missing env variable handling

## Testing
- `go vet ./...`
- `go test ./...`
