### PR TITLE
Add Okta and Workday integration plugins

### DIFF
--- a/app/integrationplugins/okta/capabilities.go
+++ b/app/integrationplugins/okta/capabilities.go
@@ -1,0 +1,26 @@
+package okta
+
+import integrationplugins "github.com/winhowes/AuthTransformer/app/integrationplugins"
+
+func init() {
+	integrationplugins.RegisterCapability("okta", "create_user", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/api/v1/users", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("okta", "update_user", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/api/v1/users/*", Methods: map[string]integrationplugins.RequestConstraint{"PUT": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("okta", "deactivate_user", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/api/v1/users/*/lifecycle/deactivate", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+}

--- a/app/integrationplugins/workday/capabilities.go
+++ b/app/integrationplugins/workday/capabilities.go
@@ -1,0 +1,12 @@
+package workday
+
+import integrationplugins "github.com/winhowes/AuthTransformer/app/integrationplugins"
+
+func init() {
+	integrationplugins.RegisterCapability("workday", "query_worker", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/api/**/workers/*", Methods: map[string]integrationplugins.RequestConstraint{"GET": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+}

--- a/cmd/allowlist/plugins/okta.go
+++ b/cmd/allowlist/plugins/okta.go
@@ -1,0 +1,7 @@
+package plugins
+
+func init() {
+	RegisterCapability("okta", "create_user", CapabilitySpec{})
+	RegisterCapability("okta", "update_user", CapabilitySpec{})
+	RegisterCapability("okta", "deactivate_user", CapabilitySpec{})
+}

--- a/cmd/allowlist/plugins/workday.go
+++ b/cmd/allowlist/plugins/workday.go
@@ -1,0 +1,5 @@
+package plugins
+
+func init() {
+	RegisterCapability("workday", "query_worker", CapabilitySpec{})
+}

--- a/cmd/integrations/main.go
+++ b/cmd/integrations/main.go
@@ -103,6 +103,30 @@ func main() {
 		}
 		integ := plugins.ServiceNow(*name, *token)
 		sendIntegration(integ)
+	case "okta":
+		fs := flag.NewFlagSet("okta", flag.ExitOnError)
+		name := fs.String("name", "okta", "integration name")
+		domain := fs.String("domain", "", "okta domain, e.g. myorg.okta.com")
+		token := fs.String("token", "", "secret reference for API token")
+		fs.Parse(args)
+		if *token == "" || *domain == "" {
+			fmt.Fprintln(os.Stderr, "-token and -domain are required")
+			os.Exit(1)
+		}
+		integ := plugins.Okta(*name, *domain, *token)
+		sendIntegration(integ)
+	case "workday":
+		fs := flag.NewFlagSet("workday", flag.ExitOnError)
+		name := fs.String("name", "workday", "integration name")
+		domain := fs.String("domain", "", "workday domain, e.g. myorg.workday.com")
+		token := fs.String("token", "", "secret reference for API token")
+		fs.Parse(args)
+		if *token == "" || *domain == "" {
+			fmt.Fprintln(os.Stderr, "-token and -domain are required")
+			os.Exit(1)
+		}
+		integ := plugins.Workday(*name, *domain, *token)
+		sendIntegration(integ)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown plugin %s\n", plugin)
 		os.Exit(1)

--- a/cmd/integrations/plugins/okta.go
+++ b/cmd/integrations/plugins/okta.go
@@ -1,0 +1,25 @@
+package plugins
+
+import "strings"
+
+// Okta returns an Integration configured for the Okta API.
+func Okta(name, domain, tokenRef string) Integration {
+	if !strings.HasPrefix(domain, "https://") && !strings.HasPrefix(domain, "http://") {
+		domain = "https://" + domain
+	}
+	dest := strings.TrimSuffix(domain, "/") + "/api/v1"
+	return Integration{
+		Name:         name,
+		Destination:  dest,
+		InRateLimit:  100,
+		OutRateLimit: 100,
+		OutgoingAuth: []AuthPluginConfig{{
+			Type: "token",
+			Params: map[string]interface{}{
+				"secrets": []string{tokenRef},
+				"header":  "Authorization",
+				"prefix":  "SSWS ",
+			},
+		}},
+	}
+}

--- a/cmd/integrations/plugins/workday.go
+++ b/cmd/integrations/plugins/workday.go
@@ -1,0 +1,25 @@
+package plugins
+
+import "strings"
+
+// Workday returns an Integration configured for the Workday API.
+func Workday(name, domain, tokenRef string) Integration {
+	if !strings.HasPrefix(domain, "https://") && !strings.HasPrefix(domain, "http://") {
+		domain = "https://" + domain
+	}
+	dest := strings.TrimSuffix(domain, "/") + "/api"
+	return Integration{
+		Name:         name,
+		Destination:  dest,
+		InRateLimit:  100,
+		OutRateLimit: 100,
+		OutgoingAuth: []AuthPluginConfig{{
+			Type: "token",
+			Params: map[string]interface{}{
+				"secrets": []string{tokenRef},
+				"header":  "Authorization",
+				"prefix":  "Bearer ",
+			},
+		}},
+	}
+}


### PR DESCRIPTION
## Summary
- add Okta and Workday integration plugin implementations
- register Okta and Workday capabilities for allowlist CLI
- support okta and workday commands in integration CLI

## Testing
- `go vet ./...`
- `go test ./...`
