### PR TITLE
Add monday integration plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,10 @@ Add Linear:
 ```bash
 go run ./cmd/integrations linear -token env:LINEAR_TOKEN
 ```
+Add Monday:
+```bash
+go run ./cmd/integrations monday -token env:MONDAY_TOKEN
+```
 Add Asana:
 ```bash
 go run ./cmd/integrations asana -token env:ASANA_TOKEN

--- a/app/integrationplugins/monday/capabilities.go
+++ b/app/integrationplugins/monday/capabilities.go
@@ -1,0 +1,26 @@
+package monday
+
+import integrationplugins "github.com/winhowes/AuthTransformer/app/integrationplugins"
+
+func init() {
+	integrationplugins.RegisterCapability("monday", "create_item", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/v2", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("monday", "update_status", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/v2", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("monday", "add_comment", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/v2", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+}

--- a/app/main.go
+++ b/app/main.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/gitlab"
 	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/jira"
 	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/linear"
+	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/monday"
 	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/sendgrid"
 	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/servicenow"
 	_ "github.com/winhowes/AuthTransformer/app/integrationplugins/slack"

--- a/cmd/allowlist/plugins/monday.go
+++ b/cmd/allowlist/plugins/monday.go
@@ -1,0 +1,7 @@
+package plugins
+
+func init() {
+	RegisterCapability("monday", "create_item", CapabilitySpec{})
+	RegisterCapability("monday", "update_status", CapabilitySpec{})
+	RegisterCapability("monday", "add_comment", CapabilitySpec{})
+}

--- a/cmd/integrations/main.go
+++ b/cmd/integrations/main.go
@@ -159,6 +159,18 @@ func main() {
 			os.Exit(1)
 		}
 		integ := plugins.Stripe(*name, *token)
+		sendIntegration(integ)
+	case "monday":
+		fs := flag.NewFlagSet("monday", flag.ExitOnError)
+		name := fs.String("name", "monday", "integration name")
+		token := fs.String("token", "", "secret reference for API token")
+		fs.Parse(args)
+		if *token == "" {
+			fmt.Fprintln(os.Stderr, "-token is required")
+			os.Exit(1)
+		}
+		integ := plugins.Monday(*name, *token)
+		sendIntegration(integ)
 	case "okta":
 		fs := flag.NewFlagSet("okta", flag.ExitOnError)
 		name := fs.String("name", "okta", "integration name")

--- a/cmd/integrations/plugins/monday.go
+++ b/cmd/integrations/plugins/monday.go
@@ -1,0 +1,18 @@
+package plugins
+
+// Monday returns an Integration configured for the monday.com API.
+func Monday(name, tokenRef string) Integration {
+	return Integration{
+		Name:         name,
+		Destination:  "https://api.monday.com/v2",
+		InRateLimit:  100,
+		OutRateLimit: 100,
+		OutgoingAuth: []AuthPluginConfig{{
+			Type: "token",
+			Params: map[string]interface{}{
+				"secrets": []string{tokenRef},
+				"header":  "Authorization",
+			},
+		}},
+	}
+}


### PR DESCRIPTION
## Summary
- add monday integration plugin and capability definitions
- register monday integration in server
- support monday integration in CLI
- document monday CLI usage

## Testing
- `go vet ./...`
- `go test ./...`
