### PR TITLE
Log upstream status codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ docker run -p 8080:8080 authtransformer
 
 ## Logging
 
-AuthTransformer writes log messages to standard output. Each request generates an entry showing the HTTP method, host, path and remote address. Authentication failures and rate limiting events are also logged. The logger is configured with Go's standard time-prefixed format.
+AuthTransformer writes log messages to standard output. Each request generates an entry showing the HTTP method, host, path and remote address. Authentication failures and rate limiting events are also logged. Responses from upstream services are logged with their HTTP status codes, allowing metrics to capture downstream errors. The logger is configured with Go's standard time-prefixed format.
 
 ## Deploying with Terraform
 

--- a/app/main.go
+++ b/app/main.go
@@ -229,7 +229,12 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	integ.proxy.ServeHTTP(w, r)
+	rec := &statusRecorder{ResponseWriter: w}
+	integ.proxy.ServeHTTP(rec, r)
+	if rec.status == 0 {
+		rec.status = http.StatusOK
+	}
+	log.Printf("Upstream response for host %s: %d", host, rec.status)
 }
 
 func main() {

--- a/app/statusrecorder.go
+++ b/app/statusrecorder.go
@@ -1,0 +1,21 @@
+package main
+
+import "net/http"
+
+// statusRecorder captures the HTTP status code written by a handler.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
+	return r.ResponseWriter.Write(b)
+}


### PR DESCRIPTION
## Summary
- capture HTTP status codes from upstream responses
- log upstream response status codes in proxy handler
- document logging of upstream status codes

## Testing
- `go vet ./...`
- `go test ./...`
