### PR TITLE
Fix integrations list subcommand

### DIFF
--- a/cmd/integrations/main.go
+++ b/cmd/integrations/main.go
@@ -22,10 +22,11 @@ func main() {
 	}
 	plugin := flag.Arg(0)
 	args := flag.Args()[1:]
-  
-  if plugin == "list" {
+
+	if plugin == "list" {
 		listIntegrations()
-  }
+		return
+	}
 
 	builder := plugins.Get(plugin)
 	if builder == nil {


### PR DESCRIPTION
## Summary
- return early when using the `list` subcommand in `cmd/integrations`

## Testing
- `go vet ./...`
- `go test ./...`
